### PR TITLE
Start OpenTelemetry

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,12 @@
+import os
+import pytest
+
+
+@pytest.fixture(scope="function", autouse=True)
+def reset_environment_between_tests():
+    old_environ = dict(os.environ)
+
+    yield
+
+    os.environ.clear()
+    os.environ.update(old_environ)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,11 @@ classifiers = [
   # Remove this to allow publishing
   "Private :: Do Not Upload"
 ]
-dependencies = []
+dependencies = [
+  "opentelemetry-api",
+  "opentelemetry-sdk",
+  "opentelemetry-exporter-otlp-proto-http",
+]
 dynamic = ["version"]
 
 [project.urls]
@@ -64,7 +68,10 @@ dependencies = [
   "black>=23.1.0",
   "mypy>=1.0.0",
   "ruff>=0.0.243",
-  "hatchling" # needed for type checking
+  "hatchling", # needed for type checking
+  "opentelemetry-api",
+  "opentelemetry-sdk",
+  "opentelemetry-exporter-otlp-proto-http",
 ]
 
 [tool.hatch.envs.lint.scripts]
@@ -112,3 +119,7 @@ exclude_lines = [
   "if __name__ == .__main__.:",
   "if TYPE_CHECKING:",
 ]
+
+[[tool.mypy.overrides]]
+module = "opentelemetry.instrumentation.*"
+ignore_missing_imports = true

--- a/src/appsignal/agent.py
+++ b/src/appsignal/agent.py
@@ -3,28 +3,12 @@ from __future__ import annotations
 import os
 import subprocess
 
-from .config import Options
-from typing import cast
+from .config import Options, set_private_environ
 
 AGENT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "appsignal-agent")
 
-OPTION_PRIVATE_ENV_VAR = Options(
-    name="_APPSIGNAL_APP_NAME",
-    push_api_key="_APPSIGNAL_PUSH_API_KEY",
-    environment="_APPSIGNAL_ENVIRONMENT",
-    log_level="_APPSIGNAL_LOG_LEVEL",
-)
-
-
-def set_agent_defaults():
-    os.environ["_APPSIGNAL_ENABLE_OPENTELEMETRY_HTTP"] = "true"
-
 
 def start_agent(config: Options):
-    set_agent_defaults()
-
-    for option, value in config.items():
-        if option in OPTION_PRIVATE_ENV_VAR:
-            os.environ[cast(dict, OPTION_PRIVATE_ENV_VAR)[option]] = str(value)
+    set_private_environ(config)
 
     subprocess.Popen([AGENT_PATH])

--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from .agent import start_agent
 from .config import from_public_environ
+from .opentelemetry import start_opentelemetry
 
 if TYPE_CHECKING:
     from typing import Unpack
@@ -16,3 +17,4 @@ class Client:
 
     def start(self):
         start_agent(self._options)
+        start_opentelemetry(self._options)

--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 from .agent import start_agent
+from .config import from_public_environ
 
 if TYPE_CHECKING:
     from typing import Unpack
@@ -11,7 +12,7 @@ class Client:
     _options: Options
 
     def __init__(self, **options: Unpack[Options]):
-        self._options = options
+        self._options = from_public_environ() | options
 
     def start(self):
         start_agent(self._options)

--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -13,7 +13,7 @@ class Client:
     _options: Options
 
     def __init__(self, **options: Unpack[Options]):
-        self._options = from_system() | from_public_environ() | options
+        self._options = from_system() | options | from_public_environ()
 
     def start(self):
         start_agent(self._options)

--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 from .agent import start_agent
-from .config import from_public_environ
+from .config import from_system, from_public_environ
 from .opentelemetry import start_opentelemetry
 
 if TYPE_CHECKING:
@@ -13,7 +13,7 @@ class Client:
     _options: Options
 
     def __init__(self, **options: Unpack[Options]):
-        self._options = from_public_environ() | options
+        self._options = from_system() | from_public_environ() | options
 
     def start(self):
         start_agent(self._options)

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -41,12 +41,17 @@ def parse_disable_default_instrumentations(
 
 
 class Options(TypedDict, total=False):
-    name: str
-    environment: str
-    push_api_key: str
-    log_level: str
-    revision: str
+    app_path: str
     disable_default_instrumentations: Union[list[DefaultInstrumentation], bool]
+    environment: str
+    log_level: str
+    name: str
+    push_api_key: str
+    revision: str
+
+
+def from_system() -> Options:
+    return Options(app_path=os.getcwd())
 
 
 def from_public_environ() -> Options:
@@ -94,7 +99,10 @@ def set_private_environ(config: Options):
 def opentelemetry_resource_attributes(config: Options):
     attributes = {
         k: v
-        for k, v in {"appsignal.config.revision": config.get("revision")}.items()
+        for k, v in {
+            "appsignal.config.revision": config.get("revision"),
+            "appsignal.config.app_path": config.get("app_path"),
+        }.items()
         if v is not None
     }
 

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from typing import cast, get_args, TypedDict, Union, Optional, Literal
 
-DEFAULT_INSTRUMENTATION = Literal[
+DefaultInstrumentation = Literal[
     "opentelemetry.instrumentation.celery",
     "opentelemetry.instrumentation.django",
     "opentelemetry.instrumentation.jinja2",
@@ -13,7 +13,7 @@ DEFAULT_INSTRUMENTATION = Literal[
 ]
 
 DEFAULT_INSTRUMENTATIONS = cast(
-    list[DEFAULT_INSTRUMENTATION], list(get_args(DEFAULT_INSTRUMENTATION))
+    list[DefaultInstrumentation], list(get_args(DefaultInstrumentation))
 )
 
 CONSTANT_PRIVATE_ENVIRON = {"_APPSIGNAL_ENABLE_OPENTELEMETRY_HTTP": "true"}
@@ -25,17 +25,17 @@ CONSTANT_RESOURCE_ATTRIBUTES = {
 
 def parse_disable_default_instrumentations(
     value: Optional[str],
-) -> Optional[Union[list[DEFAULT_INSTRUMENTATION], bool]]:
+) -> Optional[Union[list[DefaultInstrumentation], bool]]:
     if value is None:
         return None
 
-    if value == "true":
+    if value.lower() == "true":
         return True
-    if value == "false":
+    if value.lower() == "false":
         return False
 
     return cast(
-        list[DEFAULT_INSTRUMENTATION],
+        list[DefaultInstrumentation],
         [x for x in value.split(",") if x in DEFAULT_INSTRUMENTATIONS],
     )
 
@@ -46,7 +46,7 @@ class Options(TypedDict, total=False):
     push_api_key: str
     log_level: str
     revision: str
-    disable_default_instrumentations: Union[list[DEFAULT_INSTRUMENTATION], bool]
+    disable_default_instrumentations: Union[list[DefaultInstrumentation], bool]
 
 
 def from_public_environ() -> Options:

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -18,6 +18,10 @@ DEFAULT_INSTRUMENTATIONS = cast(
 
 CONSTANT_PRIVATE_ENVIRON = {"_APPSIGNAL_ENABLE_OPENTELEMETRY_HTTP": "true"}
 
+CONSTANT_RESOURCE_ATTRIBUTES = {
+    "appsignal.config.language_integration": "python",
+}
+
 
 def parse_disable_default_instrumentations(
     value: Optional[str],
@@ -85,3 +89,13 @@ def set_private_environ(config: Options):
     for var, value in private_environ.items():
         if value is not None:
             os.environ[var] = str(value)
+
+
+def opentelemetry_resource_attributes(config: Options):
+    attributes = {
+        k: v
+        for k, v in {"appsignal.config.revision": config.get("revision")}.items()
+        if v is not None
+    }
+
+    return attributes | CONSTANT_RESOURCE_ATTRIBUTES

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from .config import Options, opentelemetry_resource_attributes, DEFAULT_INSTRUMENTATION
+
+from typing import Callable
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+
+def add_celery_instrumentation():
+    from opentelemetry.instrumentation.celery import CeleryInstrumentor
+
+    CeleryInstrumentor().instrument()
+
+
+def add_django_instrumentation():
+    from opentelemetry.instrumentation.django import DjangoInstrumentor
+    import json
+
+    def response_hook(span, request, response):
+        span.set_attribute(
+            "appsignal.request.parameters",
+            json.dumps({"GET": request.GET, "POST": request.POST}),
+        )
+
+    DjangoInstrumentor().instrument(response_hook=response_hook)
+
+
+def add_jinja2_instrumentation():
+    from opentelemetry.instrumentation.jinja2 import Jinja2Instrumentor
+
+    Jinja2Instrumentor().instrument()
+
+
+def add_psycopg2_instrumentation():
+    from opentelemetry.instrumentation.psycopg2 import Psycopg2Instrumentor
+
+    Psycopg2Instrumentor().instrument(enable_commenter=True, commenter_options={})
+
+
+def add_redis_instrumentation():
+    from opentelemetry.instrumentation.redis import RedisInstrumentor
+
+    RedisInstrumentor().instrument(sanitize_query=True)
+
+
+def add_requests_instrumentation():
+    from opentelemetry.instrumentation.requests import RequestsInstrumentor
+
+    RequestsInstrumentor().instrument()
+
+
+DEFAULT_INSTRUMENTATION_ADDERS: dict[DEFAULT_INSTRUMENTATION, Callable[[], None]] = {
+    "opentelemetry.instrumentation.celery": add_celery_instrumentation,
+    "opentelemetry.instrumentation.django": add_django_instrumentation,
+    "opentelemetry.instrumentation.jinja2": add_jinja2_instrumentation,
+    "opentelemetry.instrumentation.psycopg2": add_psycopg2_instrumentation,
+    "opentelemetry.instrumentation.redis": add_redis_instrumentation,
+    "opentelemetry.instrumentation.requests": add_requests_instrumentation,
+}
+
+
+def start_opentelemetry(config: Options):
+    resource = Resource(attributes=opentelemetry_resource_attributes(config))
+    provider = TracerProvider(resource=resource)
+
+    otlp_exporter = OTLPSpanExporter(endpoint="http://localhost:8099")
+    exporter_processor = BatchSpanProcessor(otlp_exporter)
+    provider.add_span_processor(exporter_processor)
+    trace.set_tracer_provider(provider)
+
+    add_instrumentations(config)
+
+
+def add_instrumentations(config: Options):
+    disable_list = config.get("disable_default_instrumentations") or []
+
+    if disable_list is True:
+        return
+
+    for name, adder in DEFAULT_INSTRUMENTATION_ADDERS.items():
+        if name not in disable_list:
+            try:
+                adder()
+            except ModuleNotFoundError:
+                pass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,10 @@
 from appsignal.client import Client
 
+import os
 
-def test_client_init():
+
+def test_client_options_merge_init_with_env():
+    os.environ["APPSIGNAL_PUSH_API_KEY"] = "some_key"
     client = Client(name="MyApp")
     assert client._options["name"] == "MyApp"
-    client.start()
+    assert client._options["push_api_key"] == "some_key"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,8 +3,9 @@ from appsignal.client import Client
 import os
 
 
-def test_client_options_merge_init_with_env():
+def test_client_options_merge_sources():
     os.environ["APPSIGNAL_PUSH_API_KEY"] = "some_key"
     client = Client(name="MyApp")
     assert client._options["name"] == "MyApp"
     assert client._options["push_api_key"] == "some_key"
+    assert "app_path" in client._options

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,85 @@
+import os
+
+from appsignal.config import (
+    Options,
+    from_public_environ,
+    set_private_environ,
+    opentelemetry_resource_attributes,
+)
+
+
+def test_from_public_environ():
+    os.environ["APPSIGNAL_APP_NAME"] = "MyApp"
+    os.environ["APPSIGNAL_APP_ENV"] = "development"
+    os.environ["APPSIGNAL_PUSH_API_KEY"] = "some-api-key"
+    os.environ["APPSIGNAL_LOG_LEVEL"] = "trace"
+    os.environ["APP_REVISION"] = "abc123"
+
+    config = from_public_environ()
+
+    assert config == Options(
+        name="MyApp",
+        environment="development",
+        push_api_key="some-api-key",
+        log_level="trace",
+        revision="abc123",
+    )
+
+
+def test_from_public_environ_disable_default_instrumentations_list():
+    os.environ["APPSIGNAL_DISABLE_DEFAULT_INSTRUMENTATIONS"] = ",".join(
+        ["opentelemetry.instrumentation.celery", "something.else"]
+    )
+
+    config = from_public_environ()
+
+    assert config["disable_default_instrumentations"] == [
+        "opentelemetry.instrumentation.celery"
+    ]
+
+
+def test_from_public_environ_disable_default_instrumentations_bool():
+    for value, expected in [
+        ("True", True),
+        ("true", True),
+        ("False", False),
+        ("false", False),
+    ]:
+        os.environ["APPSIGNAL_DISABLE_DEFAULT_INSTRUMENTATIONS"] = value
+        config = from_public_environ()
+        assert config["disable_default_instrumentations"] is expected
+
+
+def test_set_private_environ():
+    config = Options(
+        name="MyApp",
+        environment="development",
+        push_api_key="some-api-key",
+        log_level="trace",
+    )
+
+    set_private_environ(config)
+
+    assert os.environ["_APPSIGNAL_APP_NAME"] == "MyApp"
+    assert os.environ["_APPSIGNAL_PUSH_API_KEY"] == "some-api-key"
+    assert os.environ["_APPSIGNAL_ENVIRONMENT"] == "development"
+    assert os.environ["_APPSIGNAL_LOG_LEVEL"] == "trace"
+
+
+def test_opentelemetry_resource_attributes():
+    config = Options(revision="abc123")
+
+    attributes = opentelemetry_resource_attributes(config)
+
+    assert attributes == {
+        "appsignal.config.revision": "abc123",
+        "appsignal.config.language_integration": "python",
+    }
+
+
+def test_opentelemetry_resource_attributes_no_revision():
+    config = Options()
+
+    attributes = opentelemetry_resource_attributes(config)
+
+    assert attributes == {"appsignal.config.language_integration": "python"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,10 +2,17 @@ import os
 
 from appsignal.config import (
     Options,
+    from_system,
     from_public_environ,
     set_private_environ,
     opentelemetry_resource_attributes,
 )
+
+
+def test_from_system():
+    config = from_system()
+
+    assert list(config.keys()) == ["app_path"]
 
 
 def test_from_public_environ():
@@ -67,19 +74,15 @@ def test_set_private_environ():
 
 
 def test_opentelemetry_resource_attributes():
-    config = Options(revision="abc123")
+    config = Options(
+        app_path="/path/to/app",
+        revision="abc123",
+    )
 
     attributes = opentelemetry_resource_attributes(config)
 
     assert attributes == {
+        "appsignal.config.app_path": "/path/to/app",
         "appsignal.config.revision": "abc123",
         "appsignal.config.language_integration": "python",
     }
-
-
-def test_opentelemetry_resource_attributes_no_revision():
-    config = Options()
-
-    attributes = opentelemetry_resource_attributes(config)
-
-    assert attributes == {"appsignal.config.language_integration": "python"}

--- a/tests/test_opentelemetry.py
+++ b/tests/test_opentelemetry.py
@@ -1,0 +1,49 @@
+from unittest.mock import Mock
+
+from appsignal.config import Options
+from appsignal.opentelemetry import add_instrumentations, DefaultInstrumentation
+
+
+def raise_module_not_found_error():
+    raise ModuleNotFoundError()
+
+
+def mock_adders() -> dict[DefaultInstrumentation, Mock]:
+    return {
+        "opentelemetry.instrumentation.celery": Mock(),
+        "opentelemetry.instrumentation.jinja2": Mock(
+            side_effect=raise_module_not_found_error
+        ),
+    }
+
+
+def test_add_instrumentations():
+    adders = mock_adders()
+    config = Options()
+
+    add_instrumentations(config, default_instrumentation_adders=adders)
+
+    for adder in adders.values():
+        adder.assert_called_once()
+
+
+def test_add_instrumentations_disable_some_default_instrumentations():
+    adders = mock_adders()
+    config = Options(
+        disable_default_instrumentations=["opentelemetry.instrumentation.celery"]
+    )
+
+    add_instrumentations(config, default_instrumentation_adders=adders)
+
+    adders["opentelemetry.instrumentation.celery"].assert_not_called()
+    adders["opentelemetry.instrumentation.jinja2"].assert_called_once()
+
+
+def test_add_instrumentations_disable_all_default_instrumentations():
+    adders = mock_adders()
+    config = Options(disable_default_instrumentations=True)
+
+    add_instrumentations(config, default_instrumentation_adders=adders)
+
+    for adder in adders.values():
+        adder.assert_not_called()


### PR DESCRIPTION
Here's a test setup PR draft to test this with: https://github.com/appsignal/test-setups/pull/98

I'm making a ton of decisions implicitly, please bikeshed! Should we "auto-detect" instrumentations in this way? Should we still have `disable_default_instrumentations`, or is the dependency opt-in enough?

Commits are a bit too intermingled because I did a lot of changes in one go, sorry.

---

### [Read configuration from the environment](https://github.com/appsignal/appsignal-python/commit/95630dab8b2c8e230b169d647d04fb2fbe3e22ef)

Move things around so that everything that relates to the configuration
options lives in `config.py`. Implement configuration options for
`revision` and `disable_default_instrumentations`, which will be used
in later commits. Allow for the configuration options to be read from
the environment.

### [Start OpenTelemetry on client start](https://github.com/appsignal/appsignal-python/commit/42ca5f0fb7eb41f70ca1a3a1b5da83bd5317bd35)

When `client.start()` is called, start OpenTelemetry, pointing its
exporter at the agent, which is also started by `client.start()`.

Automatic instrumentation is only provided if the corresponding
OpenTelemetry package is installed -- that's the signal to "opt in".
This keeps our package light on dependencies.