### PR TITLE
Add Git linter to the CI build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -21,6 +21,9 @@ blocks:
     - name: Typing
       commands:
       - "hatch run lint:typing"
+    - name: Git Lint (Lintje)
+      commands:
+      - script/lint_git
 - name: Tests
   dependencies: []
   task:

--- a/script/lint_git
+++ b/script/lint_git
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -eu
+
+LINTJE_VERSION="0.11.3"
+
+mkdir -p "$HOME/bin"
+cache_key=v1-lintje-$LINTJE_VERSION
+cache restore $cache_key
+
+# File exists and is executable
+if [ -x "$HOME/bin/lintje" ]; then
+  echo "Restored Lintje $LINTJE_VERSION from cache"
+else
+  echo "Downloading Lintje $LINTJE_VERSION"
+  curl -L \
+    https://github.com/lintje/lintje/releases/download/v$LINTJE_VERSION/x86_64-unknown-linux-gnu.tar.gz | \
+    tar -xz --directory "$HOME/bin"
+  cache store $cache_key "$HOME/bin/lintje"
+fi
+
+"$HOME/bin/lintje" "$SEMAPHORE_GIT_COMMIT_RANGE"


### PR DESCRIPTION
Make sure we follow the same Git styleguide across all integration projects by adding the Lintje Git linter to the project.

Script copy-pasted from the Ruby gem.

https://github.com/appsignal/appsignal-ruby/blob/1fc86ae5a087b3589f91d25f661ef94f459895cd/script/lint_git

Closes #4