### PR TITLE
Configure mono for package

### DIFF
--- a/mono.yml
+++ b/mono.yml
@@ -1,0 +1,15 @@
+---
+language: custom
+repo: "https://github.com/appsignal/appsignal-python"
+bootstrap:
+  command: ""
+clean:
+  command: "hatch clean"
+build:
+  command: "hatch run build:all"
+publish:
+  command: "hatch publish"
+test:
+  command: "hatch run test:pytest"
+read_version: "hatch version"
+write_version: "hatch version"


### PR DESCRIPTION
Configure mono for a custom language, as it doesn't directly support Python (yet).

Add scripts to read and update the package version. These will be called by mono, PR https://github.com/appsignal/mono/pull/52.

Part of #3 