### PR TITLE
Config hostname

### DIFF
--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -66,10 +66,10 @@ def from_public_environ() -> Options:
     # value, then remove the ones whose values are empty strings.
 
     config = Options(
-        name=os.environ.get("APPSIGNAL_APP_NAME", ""),
         environment=os.environ.get("APPSIGNAL_APP_ENV", ""),
-        push_api_key=os.environ.get("APPSIGNAL_PUSH_API_KEY", ""),
         log_level=os.environ.get("APPSIGNAL_LOG_LEVEL", ""),
+        name=os.environ.get("APPSIGNAL_APP_NAME", ""),
+        push_api_key=os.environ.get("APPSIGNAL_PUSH_API_KEY", ""),
         revision=os.environ.get("APP_REVISION", ""),
     )
 
@@ -87,8 +87,8 @@ def set_private_environ(config: Options):
     private_environ = {
         "_APPSIGNAL_APP_ENV": config.get("environment"),
         "_APPSIGNAL_APP_NAME": config.get("name"),
-        "_APPSIGNAL_PUSH_API_KEY": config.get("push_api_key"),
         "_APPSIGNAL_LOG_LEVEL": config.get("log_level"),
+        "_APPSIGNAL_PUSH_API_KEY": config.get("push_api_key"),
     } | CONSTANT_PRIVATE_ENVIRON
 
     for var, value in private_environ.items():
@@ -100,8 +100,8 @@ def opentelemetry_resource_attributes(config: Options):
     attributes = {
         k: v
         for k, v in {
-            "appsignal.config.revision": config.get("revision"),
             "appsignal.config.app_path": config.get("app_path"),
+            "appsignal.config.revision": config.get("revision"),
         }.items()
         if v is not None
     }

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -44,6 +44,7 @@ class Options(TypedDict, total=False):
     app_path: str
     disable_default_instrumentations: Union[list[DefaultInstrumentation], bool]
     environment: str
+    hostname: str
     log_level: str
     name: str
     push_api_key: str
@@ -67,6 +68,7 @@ def from_public_environ() -> Options:
 
     config = Options(
         environment=os.environ.get("APPSIGNAL_APP_ENV", ""),
+        hostname=os.environ.get("APPSIGNAL_HOSTNAME", ""),
         log_level=os.environ.get("APPSIGNAL_LOG_LEVEL", ""),
         name=os.environ.get("APPSIGNAL_APP_NAME", ""),
         push_api_key=os.environ.get("APPSIGNAL_PUSH_API_KEY", ""),
@@ -87,6 +89,7 @@ def set_private_environ(config: Options):
     private_environ = {
         "_APPSIGNAL_APP_ENV": config.get("environment"),
         "_APPSIGNAL_APP_NAME": config.get("name"),
+        "_APPSIGNAL_HOSTNAME": config.get("hostname"),
         "_APPSIGNAL_LOG_LEVEL": config.get("log_level"),
         "_APPSIGNAL_PUSH_API_KEY": config.get("push_api_key"),
     } | CONSTANT_PRIVATE_ENVIRON

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,7 @@ def test_from_system():
 def test_from_public_environ():
     os.environ["APPSIGNAL_APP_ENV"] = "development"
     os.environ["APPSIGNAL_APP_NAME"] = "MyApp"
+    os.environ["APPSIGNAL_HOSTNAME"] = "Test hostname"
     os.environ["APPSIGNAL_LOG_LEVEL"] = "trace"
     os.environ["APPSIGNAL_PUSH_API_KEY"] = "some-api-key"
     os.environ["APP_REVISION"] = "abc123"
@@ -26,6 +27,7 @@ def test_from_public_environ():
 
     assert config == Options(
         environment="development",
+        hostname="Test hostname",
         log_level="trace",
         name="MyApp",
         push_api_key="some-api-key",
@@ -60,6 +62,7 @@ def test_from_public_environ_disable_default_instrumentations_bool():
 def test_set_private_environ():
     config = Options(
         environment="development",
+        hostname="Test hostname",
         log_level="trace",
         name="MyApp",
         push_api_key="some-api-key",
@@ -69,6 +72,7 @@ def test_set_private_environ():
 
     assert os.environ["_APPSIGNAL_APP_ENV"] == "development"
     assert os.environ["_APPSIGNAL_APP_NAME"] == "MyApp"
+    assert os.environ["_APPSIGNAL_HOSTNAME"] == "Test hostname"
     assert os.environ["_APPSIGNAL_LOG_LEVEL"] == "trace"
     assert os.environ["_APPSIGNAL_PUSH_API_KEY"] == "some-api-key"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,19 +16,19 @@ def test_from_system():
 
 
 def test_from_public_environ():
-    os.environ["APPSIGNAL_APP_NAME"] = "MyApp"
     os.environ["APPSIGNAL_APP_ENV"] = "development"
-    os.environ["APPSIGNAL_PUSH_API_KEY"] = "some-api-key"
+    os.environ["APPSIGNAL_APP_NAME"] = "MyApp"
     os.environ["APPSIGNAL_LOG_LEVEL"] = "trace"
+    os.environ["APPSIGNAL_PUSH_API_KEY"] = "some-api-key"
     os.environ["APP_REVISION"] = "abc123"
 
     config = from_public_environ()
 
     assert config == Options(
-        name="MyApp",
         environment="development",
-        push_api_key="some-api-key",
         log_level="trace",
+        name="MyApp",
+        push_api_key="some-api-key",
         revision="abc123",
     )
 
@@ -59,18 +59,18 @@ def test_from_public_environ_disable_default_instrumentations_bool():
 
 def test_set_private_environ():
     config = Options(
-        name="MyApp",
         environment="development",
-        push_api_key="some-api-key",
         log_level="trace",
+        name="MyApp",
+        push_api_key="some-api-key",
     )
 
     set_private_environ(config)
 
     assert os.environ["_APPSIGNAL_APP_ENV"] == "development"
     assert os.environ["_APPSIGNAL_APP_NAME"] == "MyApp"
-    assert os.environ["_APPSIGNAL_PUSH_API_KEY"] == "some-api-key"
     assert os.environ["_APPSIGNAL_LOG_LEVEL"] == "trace"
+    assert os.environ["_APPSIGNAL_PUSH_API_KEY"] == "some-api-key"
 
 
 def test_opentelemetry_resource_attributes():
@@ -83,6 +83,6 @@ def test_opentelemetry_resource_attributes():
 
     assert attributes == {
         "appsignal.config.app_path": "/path/to/app",
-        "appsignal.config.revision": "abc123",
         "appsignal.config.language_integration": "python",
+        "appsignal.config.revision": "abc123",
     }


### PR DESCRIPTION
## Sort config options alphabetically

Makes it easier to edit if everything is sorted alphabetically. We've also done this in the Node.js integration recently.

## Add hostname config option

Allow people to edit the hostname reported for the app.

[skip changeset]