### PR TITLE
Set the language integration as an env var

### DIFF
--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from .__about__ import __version__
 
 import os
 from typing import cast, get_args, TypedDict, Union, Optional, Literal
@@ -16,10 +17,9 @@ DEFAULT_INSTRUMENTATIONS = cast(
     list[DefaultInstrumentation], list(get_args(DefaultInstrumentation))
 )
 
-CONSTANT_PRIVATE_ENVIRON = {"_APPSIGNAL_ENABLE_OPENTELEMETRY_HTTP": "true"}
-
-CONSTANT_RESOURCE_ATTRIBUTES = {
-    "appsignal.config.language_integration": "python",
+CONSTANT_PRIVATE_ENVIRON = {
+    "_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION": f"python-{__version__}",
+    "_APPSIGNAL_ENABLE_OPENTELEMETRY_HTTP": "true",
 }
 
 
@@ -109,4 +109,4 @@ def opentelemetry_resource_attributes(config: Options):
         if v is not None
     }
 
-    return attributes | CONSTANT_RESOURCE_ATTRIBUTES
+    return attributes

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 import os
+from appsignal.__about__ import __version__
 
 from appsignal.config import (
     Options,
@@ -75,6 +76,9 @@ def test_set_private_environ():
     assert os.environ["_APPSIGNAL_HOSTNAME"] == "Test hostname"
     assert os.environ["_APPSIGNAL_LOG_LEVEL"] == "trace"
     assert os.environ["_APPSIGNAL_PUSH_API_KEY"] == "some-api-key"
+    assert (
+        os.environ["_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION"] == f"python-{__version__}"
+    )
 
 
 def test_opentelemetry_resource_attributes():
@@ -87,6 +91,5 @@ def test_opentelemetry_resource_attributes():
 
     assert attributes == {
         "appsignal.config.app_path": "/path/to/app",
-        "appsignal.config.language_integration": "python",
         "appsignal.config.revision": "abc123",
     }


### PR DESCRIPTION
Set the language integration version as an env var, rather than a resource attribute. We don't need to the particular use case of the resource attributes here.

Also include the package's version number this way so we know which package version the reported data is sent from.

[skip changeset]