### PR TITLE
Move resource attributes to private env var config

### DIFF
--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -82,24 +82,13 @@ def set_private_environ(config: Options):
     private_environ = {
         "_APPSIGNAL_APP_ENV": config.get("environment"),
         "_APPSIGNAL_APP_NAME": config.get("name"),
+        "_APPSIGNAL_APP_PATH": config.get("app_path"),
         "_APPSIGNAL_HOSTNAME": config.get("hostname"),
         "_APPSIGNAL_LOG_LEVEL": config.get("log_level"),
         "_APPSIGNAL_PUSH_API_KEY": config.get("push_api_key"),
+        "_APP_REVISION": config.get("revision"),
     } | CONSTANT_PRIVATE_ENVIRON
 
     for var, value in private_environ.items():
         if value is not None:
             os.environ[var] = str(value)
-
-
-def opentelemetry_resource_attributes(config: Options):
-    attributes = {
-        k: v
-        for k, v in {
-            "appsignal.config.app_path": config.get("app_path"),
-            "appsignal.config.revision": config.get("revision"),
-        }.items()
-        if v is not None
-    }
-
-    return attributes

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from .config import Options, opentelemetry_resource_attributes, DefaultInstrumentation
+from .config import Options, DefaultInstrumentation
 
 from typing import Callable
 
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
@@ -68,8 +67,7 @@ DEFAULT_INSTRUMENTATION_ADDERS: DefaultInstrumentationAdders = {
 
 
 def start_opentelemetry(config: Options):
-    resource = Resource(attributes=opentelemetry_resource_attributes(config))
-    provider = TracerProvider(resource=resource)
+    provider = TracerProvider()
 
     otlp_exporter = OTLPSpanExporter(endpoint="http://localhost:8099")
     exporter_processor = BatchSpanProcessor(otlp_exporter)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,6 @@ from appsignal.config import (
     from_system,
     from_public_environ,
     set_private_environ,
-    opentelemetry_resource_attributes,
 )
 
 
@@ -62,34 +61,24 @@ def test_from_public_environ_disable_default_instrumentations_bool():
 
 def test_set_private_environ():
     config = Options(
+        app_path="/path/to/app",
         environment="development",
         hostname="Test hostname",
         log_level="trace",
         name="MyApp",
         push_api_key="some-api-key",
+        revision="abc123",
     )
 
     set_private_environ(config)
 
     assert os.environ["_APPSIGNAL_APP_ENV"] == "development"
     assert os.environ["_APPSIGNAL_APP_NAME"] == "MyApp"
+    assert os.environ["_APPSIGNAL_APP_PATH"] == "/path/to/app"
     assert os.environ["_APPSIGNAL_HOSTNAME"] == "Test hostname"
     assert os.environ["_APPSIGNAL_LOG_LEVEL"] == "trace"
     assert os.environ["_APPSIGNAL_PUSH_API_KEY"] == "some-api-key"
     assert (
         os.environ["_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION"] == f"python-{__version__}"
     )
-
-
-def test_opentelemetry_resource_attributes():
-    config = Options(
-        app_path="/path/to/app",
-        revision="abc123",
-    )
-
-    attributes = opentelemetry_resource_attributes(config)
-
-    assert attributes == {
-        "appsignal.config.app_path": "/path/to/app",
-        "appsignal.config.revision": "abc123",
-    }
+    assert os.environ["_APP_REVISION"] == "abc123"


### PR DESCRIPTION
Configure the agent's app path and revision using the env var. This scenario doesn't need it to be configured using the resource attribute. We fully control how the agent is started using the Python package.

The `app_path` config option isn't something people need to configure 99% of time, but let's leave it in for that one edge case and to make it easier to test.

[skip changeset]
