### PR TITLE
Auto cancel builds on Semaphore CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,5 +1,8 @@
 version: v1.0
 name: AppSignal for Python
+auto_cancel:
+  running:
+    when: branch != 'main' AND branch != 'develop'
 agent:
   machine:
     type: e1-standard-2


### PR DESCRIPTION
When we (force) push on a branch, cancel the previous build. This saves time on waiting for the previous build to send, and the next one to start.

The main and develop branch are excluded, because we would like to know if every (merge) commit passes there.

[skip changeset]