### PR TITLE
Add config options of the list type

### DIFF
--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -36,6 +36,13 @@ def parse_bool(value: Optional[str]) -> Optional[bool]:
     return None
 
 
+def parse_list(value: Optional[str]) -> Optional[list[str]]:
+    if value is None:
+        return None
+
+    return value.split(",")
+
+
 def parse_disable_default_instrumentations(
     value: Optional[str],
 ) -> Optional[Union[list[DefaultInstrumentation], bool]]:
@@ -59,12 +66,18 @@ class Options(TypedDict, total=False):
     disable_default_instrumentations: Optional[
         Union[list[DefaultInstrumentation], bool]
     ]
+    dns_servers: Optional[list[str]]
     enable_host_metrics: Optional[bool]
     enable_nginx_metrics: Optional[bool]
     enable_statsd: Optional[bool]
     environment: Optional[str]
     files_world_accessible: Optional[bool]
+    filter_parameters: Optional[list[str]]
+    filter_session_data: Optional[list[str]]
     hostname: Optional[str]
+    ignore_actions: Optional[list[str]]
+    ignore_errors: Optional[list[str]]
+    ignore_namespaces: Optional[list[str]]
     log_level: Optional[str]
     name: Optional[str]
     push_api_key: Optional[str]
@@ -96,6 +109,7 @@ def from_public_environ() -> Options:
         disable_default_instrumentations=parse_disable_default_instrumentations(
             os.environ.get("APPSIGNAL_DISABLE_DEFAULT_INSTRUMENTATIONS")
         ),
+        dns_servers=parse_list(os.environ.get("APPSIGNAL_DNS_SERVERS")),
         enable_host_metrics=parse_bool(os.environ.get("APPSIGNAL_ENABLE_HOST_METRICS")),
         enable_nginx_metrics=parse_bool(
             os.environ.get("APPSIGNAL_ENABLE_NGINX_METRICS")
@@ -105,7 +119,12 @@ def from_public_environ() -> Options:
         files_world_accessible=parse_bool(
             os.environ.get("APPSIGNAL_FILES_WORLD_ACCESSIBLE")
         ),
+        filter_parameters=parse_list(os.environ.get("APPSIGNAL_FILTER_PARAMETERS")),
+        filter_session_data=parse_list(os.environ.get("APPSIGNAL_FILTER_SESSION_DATA")),
         hostname=os.environ.get("APPSIGNAL_HOSTNAME"),
+        ignore_actions=parse_list(os.environ.get("APPSIGNAL_IGNORE_ACTIONS")),
+        ignore_errors=parse_list(os.environ.get("APPSIGNAL_IGNORE_ERRORS")),
+        ignore_namespaces=parse_list(os.environ.get("APPSIGNAL_IGNORE_NAMESPACES")),
         log_level=os.environ.get("APPSIGNAL_LOG_LEVEL"),
         name=os.environ.get("APPSIGNAL_APP_NAME"),
         push_api_key=os.environ.get("APPSIGNAL_PUSH_API_KEY"),
@@ -134,12 +153,20 @@ def bool_to_env_str(value: Optional[bool]):
     return str(value).lower()
 
 
+def list_to_env_str(value: Optional[list[str]]):
+    if value is None:
+        return None
+
+    return ",".join(value)
+
+
 def set_private_environ(config: Options):
     private_environ = {
         "_APPSIGNAL_ACTIVE": bool_to_env_str(config.get("active")),
         "_APPSIGNAL_APP_ENV": config.get("environment"),
         "_APPSIGNAL_APP_NAME": config.get("name"),
         "_APPSIGNAL_APP_PATH": config.get("app_path"),
+        "_APPSIGNAL_DNS_SERVERS": list_to_env_str(config.get("dns_servers")),
         "_APPSIGNAL_ENABLE_HOST_METRICS": bool_to_env_str(
             config.get("enable_host_metrics")
         ),
@@ -150,7 +177,18 @@ def set_private_environ(config: Options):
         "_APPSIGNAL_FILES_WORLD_ACCESSIBLE": bool_to_env_str(
             config.get("files_world_accessible")
         ),
+        "_APPSIGNAL_FILTER_PARAMETERS": list_to_env_str(
+            config.get("filter_parameters")
+        ),
+        "_APPSIGNAL_FILTER_SESSION_DATA": list_to_env_str(
+            config.get("filter_session_data")
+        ),
         "_APPSIGNAL_HOSTNAME": config.get("hostname"),
+        "_APPSIGNAL_IGNORE_ACTIONS": list_to_env_str(config.get("ignore_actions")),
+        "_APPSIGNAL_IGNORE_ERRORS": list_to_env_str(config.get("ignore_errors")),
+        "_APPSIGNAL_IGNORE_NAMESPACES": list_to_env_str(
+            config.get("ignore_namespaces")
+        ),
         "_APPSIGNAL_LOG_LEVEL": config.get("log_level"),
         "_APPSIGNAL_PUSH_API_KEY": config.get("push_api_key"),
         "_APPSIGNAL_RUNNING_IN_CONTAINER": bool_to_env_str(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,11 +19,17 @@ def test_from_public_environ():
     os.environ["APPSIGNAL_ACTIVE"] = "true"
     os.environ["APPSIGNAL_APP_ENV"] = "development"
     os.environ["APPSIGNAL_APP_NAME"] = "MyApp"
+    os.environ["APPSIGNAL_DNS_SERVERS"] = "8.8.8.8,8.8.4.4"
     os.environ["APPSIGNAL_ENABLE_HOST_METRICS"] = "true"
     os.environ["APPSIGNAL_ENABLE_NGINX_METRICS"] = "false"
     os.environ["APPSIGNAL_ENABLE_STATSD"] = "false"
     os.environ["APPSIGNAL_FILES_WORLD_ACCESSIBLE"] = "true"
+    os.environ["APPSIGNAL_FILTER_PARAMETERS"] = "password,secret"
+    os.environ["APPSIGNAL_FILTER_SESSION_DATA"] = "key1,key2"
     os.environ["APPSIGNAL_HOSTNAME"] = "Test hostname"
+    os.environ["APPSIGNAL_IGNORE_ACTIONS"] = "action1,action2"
+    os.environ["APPSIGNAL_IGNORE_ERRORS"] = "error1,error2"
+    os.environ["APPSIGNAL_IGNORE_NAMESPACES"] = "namespace1,namespace2"
     os.environ["APPSIGNAL_LOG_LEVEL"] = "trace"
     os.environ["APPSIGNAL_PUSH_API_KEY"] = "some-api-key"
     os.environ["APPSIGNAL_RUNNING_IN_CONTAINER"] = "true"
@@ -36,12 +42,18 @@ def test_from_public_environ():
 
     assert config == Options(
         active=True,
+        dns_servers=["8.8.8.8", "8.8.4.4"],
         enable_host_metrics=True,
         enable_nginx_metrics=False,
         enable_statsd=False,
         environment="development",
         files_world_accessible=True,
+        filter_parameters=["password", "secret"],
+        filter_session_data=["key1", "key2"],
         hostname="Test hostname",
+        ignore_actions=["action1", "action2"],
+        ignore_errors=["error1", "error2"],
+        ignore_namespaces=["namespace1", "namespace2"],
         log_level="trace",
         name="MyApp",
         push_api_key="some-api-key",
@@ -103,12 +115,18 @@ def test_set_private_environ():
     config = Options(
         active=True,
         app_path="/path/to/app",
+        dns_servers=["8.8.8.8", "8.8.4.4"],
         enable_host_metrics=True,
         enable_nginx_metrics=False,
         enable_statsd=False,
         environment="development",
         files_world_accessible=True,
+        filter_parameters=["password", "secret"],
+        filter_session_data=["key1", "key2"],
         hostname="Test hostname",
+        ignore_actions=["action1", "action2"],
+        ignore_errors=["error1", "error2"],
+        ignore_namespaces=["namespace1", "namespace2"],
         log_level="trace",
         name="MyApp",
         push_api_key="some-api-key",
@@ -125,11 +143,17 @@ def test_set_private_environ():
     assert os.environ["_APPSIGNAL_APP_ENV"] == "development"
     assert os.environ["_APPSIGNAL_APP_NAME"] == "MyApp"
     assert os.environ["_APPSIGNAL_APP_PATH"] == "/path/to/app"
+    assert os.environ["_APPSIGNAL_DNS_SERVERS"] == "8.8.8.8,8.8.4.4"
     assert os.environ["_APPSIGNAL_ENABLE_HOST_METRICS"] == "true"
     assert os.environ["_APPSIGNAL_ENABLE_NGINX_METRICS"] == "false"
     assert os.environ["_APPSIGNAL_ENABLE_STATSD"] == "false"
     assert os.environ["_APPSIGNAL_FILES_WORLD_ACCESSIBLE"] == "true"
+    assert os.environ["_APPSIGNAL_FILTER_PARAMETERS"] == "password,secret"
+    assert os.environ["_APPSIGNAL_FILTER_SESSION_DATA"] == "key1,key2"
     assert os.environ["_APPSIGNAL_HOSTNAME"] == "Test hostname"
+    assert os.environ["_APPSIGNAL_IGNORE_ACTIONS"] == "action1,action2"
+    assert os.environ["_APPSIGNAL_IGNORE_ERRORS"] == "error1,error2"
+    assert os.environ["_APPSIGNAL_IGNORE_NAMESPACES"] == "namespace1,namespace2"
     assert os.environ["_APPSIGNAL_LOG_LEVEL"] == "trace"
     assert os.environ["_APPSIGNAL_PUSH_API_KEY"] == "some-api-key"
     assert (
@@ -150,3 +174,13 @@ def test_set_private_environ_bool_is_none():
     set_private_environ(config)
 
     assert os.environ.get("_APPSIGNAL_ACTIVE") is None
+
+
+def test_set_private_environ_list_is_none():
+    config = Options(
+        dns_servers=None,
+    )
+
+    set_private_environ(config)
+
+    assert os.environ.get("_APPSIGNAL_DNS_SERVERS") is None


### PR DESCRIPTION
Parse lists from environment variables, and format them again when set as private env vars for the agent.

I left out request_headers, because we should check what the default for that should be in more detail. This is more the general structure of parsing and setting config options that the client does not directly use (right now).

[skip changeset]
Part of #16
Based on #28