### PR TITLE
Add string config options

### DIFF
--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -70,11 +70,13 @@ class Options(TypedDict, total=False):
     enable_host_metrics: Optional[bool]
     enable_nginx_metrics: Optional[bool]
     enable_statsd: Optional[bool]
+    endpoint: Optional[str]
     environment: Optional[str]
     files_world_accessible: Optional[bool]
     filter_parameters: Optional[list[str]]
     filter_session_data: Optional[list[str]]
     hostname: Optional[str]
+    http_proxy: Optional[str]
     ignore_actions: Optional[list[str]]
     ignore_errors: Optional[list[str]]
     ignore_namespaces: Optional[list[str]]
@@ -86,12 +88,14 @@ class Options(TypedDict, total=False):
     send_environment_metadata: Optional[bool]
     send_params: Optional[bool]
     send_session_data: Optional[bool]
+    working_directory_path: Optional[str]
 
 
 DEFAULT_CONFIG = Options(
     enable_host_metrics=True,
     enable_nginx_metrics=False,
     enable_statsd=False,
+    endpoint="https://push.appsignal.com",
     files_world_accessible=True,
     send_environment_metadata=True,
     send_params=True,
@@ -115,6 +119,7 @@ def from_public_environ() -> Options:
             os.environ.get("APPSIGNAL_ENABLE_NGINX_METRICS")
         ),
         enable_statsd=parse_bool(os.environ.get("APPSIGNAL_ENABLE_STATSD")),
+        endpoint=os.environ.get("APPSIGNAL_PUSH_API_ENDPOINT"),
         environment=os.environ.get("APPSIGNAL_APP_ENV"),
         files_world_accessible=parse_bool(
             os.environ.get("APPSIGNAL_FILES_WORLD_ACCESSIBLE")
@@ -122,6 +127,7 @@ def from_public_environ() -> Options:
         filter_parameters=parse_list(os.environ.get("APPSIGNAL_FILTER_PARAMETERS")),
         filter_session_data=parse_list(os.environ.get("APPSIGNAL_FILTER_SESSION_DATA")),
         hostname=os.environ.get("APPSIGNAL_HOSTNAME"),
+        http_proxy=os.environ.get("APPSIGNAL_HTTP_PROXY"),
         ignore_actions=parse_list(os.environ.get("APPSIGNAL_IGNORE_ACTIONS")),
         ignore_errors=parse_list(os.environ.get("APPSIGNAL_IGNORE_ERRORS")),
         ignore_namespaces=parse_list(os.environ.get("APPSIGNAL_IGNORE_NAMESPACES")),
@@ -137,6 +143,7 @@ def from_public_environ() -> Options:
         ),
         send_params=parse_bool(os.environ.get("APPSIGNAL_SEND_PARAMS")),
         send_session_data=parse_bool(os.environ.get("APPSIGNAL_SEND_SESSION_DATA")),
+        working_directory_path=os.environ.get("APPSIGNAL_WORKING_DIRECTORY_PATH"),
     )
 
     for key, value in list(config.items()):
@@ -184,6 +191,7 @@ def set_private_environ(config: Options):
             config.get("filter_session_data")
         ),
         "_APPSIGNAL_HOSTNAME": config.get("hostname"),
+        "_APPSIGNAL_HTTP_PROXY": config.get("http_proxy"),
         "_APPSIGNAL_IGNORE_ACTIONS": list_to_env_str(config.get("ignore_actions")),
         "_APPSIGNAL_IGNORE_ERRORS": list_to_env_str(config.get("ignore_errors")),
         "_APPSIGNAL_IGNORE_NAMESPACES": list_to_env_str(
@@ -191,6 +199,7 @@ def set_private_environ(config: Options):
         ),
         "_APPSIGNAL_LOG_LEVEL": config.get("log_level"),
         "_APPSIGNAL_PUSH_API_KEY": config.get("push_api_key"),
+        "_APPSIGNAL_PUSH_API_ENDPOINT": config.get("endpoint"),
         "_APPSIGNAL_RUNNING_IN_CONTAINER": bool_to_env_str(
             config.get("running_in_container")
         ),
@@ -201,6 +210,7 @@ def set_private_environ(config: Options):
         "_APPSIGNAL_SEND_SESSION_DATA": bool_to_env_str(
             config.get("send_session_data")
         ),
+        "_APPSIGNAL_WORKING_DIRECTORY_PATH": config.get("working_directory_path"),
         "_APP_REVISION": config.get("revision"),
     } | CONSTANT_PRIVATE_ENVIRON
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,15 +27,18 @@ def test_from_public_environ():
     os.environ["APPSIGNAL_FILTER_PARAMETERS"] = "password,secret"
     os.environ["APPSIGNAL_FILTER_SESSION_DATA"] = "key1,key2"
     os.environ["APPSIGNAL_HOSTNAME"] = "Test hostname"
+    os.environ["APPSIGNAL_HTTP_PROXY"] = "http://proxy.local:9999"
     os.environ["APPSIGNAL_IGNORE_ACTIONS"] = "action1,action2"
     os.environ["APPSIGNAL_IGNORE_ERRORS"] = "error1,error2"
     os.environ["APPSIGNAL_IGNORE_NAMESPACES"] = "namespace1,namespace2"
     os.environ["APPSIGNAL_LOG_LEVEL"] = "trace"
     os.environ["APPSIGNAL_PUSH_API_KEY"] = "some-api-key"
+    os.environ["APPSIGNAL_PUSH_API_ENDPOINT"] = "https://push.appsignal.com"
     os.environ["APPSIGNAL_RUNNING_IN_CONTAINER"] = "true"
     os.environ["APPSIGNAL_SEND_ENVIRONMENT_METADATA"] = "true"
     os.environ["APPSIGNAL_SEND_PARAMS"] = "true"
     os.environ["APPSIGNAL_SEND_SESSION_DATA"] = "true"
+    os.environ["APPSIGNAL_WORKING_DIRECTORY_PATH"] = "/path/to/working/dir"
     os.environ["APP_REVISION"] = "abc123"
 
     config = from_public_environ()
@@ -46,11 +49,13 @@ def test_from_public_environ():
         enable_host_metrics=True,
         enable_nginx_metrics=False,
         enable_statsd=False,
+        endpoint="https://push.appsignal.com",
         environment="development",
         files_world_accessible=True,
         filter_parameters=["password", "secret"],
         filter_session_data=["key1", "key2"],
         hostname="Test hostname",
+        http_proxy="http://proxy.local:9999",
         ignore_actions=["action1", "action2"],
         ignore_errors=["error1", "error2"],
         ignore_namespaces=["namespace1", "namespace2"],
@@ -62,6 +67,7 @@ def test_from_public_environ():
         send_environment_metadata=True,
         send_params=True,
         send_session_data=True,
+        working_directory_path="/path/to/working/dir",
     )
 
 
@@ -119,11 +125,13 @@ def test_set_private_environ():
         enable_host_metrics=True,
         enable_nginx_metrics=False,
         enable_statsd=False,
+        endpoint="https://push.appsignal.com",
         environment="development",
         files_world_accessible=True,
         filter_parameters=["password", "secret"],
         filter_session_data=["key1", "key2"],
         hostname="Test hostname",
+        http_proxy="http://proxy.local:9999",
         ignore_actions=["action1", "action2"],
         ignore_errors=["error1", "error2"],
         ignore_namespaces=["namespace1", "namespace2"],
@@ -135,6 +143,7 @@ def test_set_private_environ():
         send_environment_metadata=True,
         send_params=True,
         send_session_data=True,
+        working_directory_path="/path/to/working/dir",
     )
 
     set_private_environ(config)
@@ -151,11 +160,13 @@ def test_set_private_environ():
     assert os.environ["_APPSIGNAL_FILTER_PARAMETERS"] == "password,secret"
     assert os.environ["_APPSIGNAL_FILTER_SESSION_DATA"] == "key1,key2"
     assert os.environ["_APPSIGNAL_HOSTNAME"] == "Test hostname"
+    assert os.environ["_APPSIGNAL_HTTP_PROXY"] == "http://proxy.local:9999"
     assert os.environ["_APPSIGNAL_IGNORE_ACTIONS"] == "action1,action2"
     assert os.environ["_APPSIGNAL_IGNORE_ERRORS"] == "error1,error2"
     assert os.environ["_APPSIGNAL_IGNORE_NAMESPACES"] == "namespace1,namespace2"
     assert os.environ["_APPSIGNAL_LOG_LEVEL"] == "trace"
     assert os.environ["_APPSIGNAL_PUSH_API_KEY"] == "some-api-key"
+    assert os.environ["_APPSIGNAL_PUSH_API_ENDPOINT"] == "https://push.appsignal.com"
     assert (
         os.environ["_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION"] == f"python-{__version__}"
     )
@@ -163,6 +174,7 @@ def test_set_private_environ():
     assert os.environ["_APPSIGNAL_SEND_ENVIRONMENT_METADATA"] == "true"
     assert os.environ["_APPSIGNAL_SEND_PARAMS"] == "true"
     assert os.environ["_APPSIGNAL_SEND_SESSION_DATA"] == "true"
+    assert os.environ["_APPSIGNAL_WORKING_DIRECTORY_PATH"] == "/path/to/working/dir"
     assert os.environ["_APP_REVISION"] == "abc123"
 
 


### PR DESCRIPTION
No parsing needed for these config options. They are not currently used by the package itself, but only configure the agent.

[skip changeset]
Part of #16