### PR TITLE
Add ca_file_path config option

### DIFF
--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -63,6 +63,7 @@ def parse_disable_default_instrumentations(
 class Options(TypedDict, total=False):
     active: Optional[bool]
     app_path: Optional[str]
+    ca_file_path: Optional[str]
     disable_default_instrumentations: Optional[
         Union[list[DefaultInstrumentation], bool]
     ]
@@ -110,6 +111,7 @@ def from_system() -> Options:
 def from_public_environ() -> Options:
     config = Options(
         active=parse_bool(os.environ.get("APPSIGNAL_ACTIVE")),
+        ca_file_path=os.environ.get("APPSIGNAL_CA_FILE_PATH"),
         disable_default_instrumentations=parse_disable_default_instrumentations(
             os.environ.get("APPSIGNAL_DISABLE_DEFAULT_INSTRUMENTATIONS")
         ),
@@ -173,6 +175,7 @@ def set_private_environ(config: Options):
         "_APPSIGNAL_APP_ENV": config.get("environment"),
         "_APPSIGNAL_APP_NAME": config.get("name"),
         "_APPSIGNAL_APP_PATH": config.get("app_path"),
+        "_APPSIGNAL_CA_FILE_PATH": config.get("ca_file_path"),
         "_APPSIGNAL_DNS_SERVERS": list_to_env_str(config.get("dns_servers")),
         "_APPSIGNAL_ENABLE_HOST_METRICS": bool_to_env_str(
             config.get("enable_host_metrics")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,6 +19,7 @@ def test_from_public_environ():
     os.environ["APPSIGNAL_ACTIVE"] = "true"
     os.environ["APPSIGNAL_APP_ENV"] = "development"
     os.environ["APPSIGNAL_APP_NAME"] = "MyApp"
+    os.environ["APPSIGNAL_CA_FILE_PATH"] = "/path/to/cacert.pem"
     os.environ["APPSIGNAL_DNS_SERVERS"] = "8.8.8.8,8.8.4.4"
     os.environ["APPSIGNAL_ENABLE_HOST_METRICS"] = "true"
     os.environ["APPSIGNAL_ENABLE_NGINX_METRICS"] = "false"
@@ -45,6 +46,7 @@ def test_from_public_environ():
 
     assert config == Options(
         active=True,
+        ca_file_path="/path/to/cacert.pem",
         dns_servers=["8.8.8.8", "8.8.4.4"],
         enable_host_metrics=True,
         enable_nginx_metrics=False,
@@ -121,6 +123,7 @@ def test_set_private_environ():
     config = Options(
         active=True,
         app_path="/path/to/app",
+        ca_file_path="/path/to/cacert.pem",
         dns_servers=["8.8.8.8", "8.8.4.4"],
         enable_host_metrics=True,
         enable_nginx_metrics=False,
@@ -152,6 +155,7 @@ def test_set_private_environ():
     assert os.environ["_APPSIGNAL_APP_ENV"] == "development"
     assert os.environ["_APPSIGNAL_APP_NAME"] == "MyApp"
     assert os.environ["_APPSIGNAL_APP_PATH"] == "/path/to/app"
+    assert os.environ["_APPSIGNAL_CA_FILE_PATH"] == "/path/to/cacert.pem"
     assert os.environ["_APPSIGNAL_DNS_SERVERS"] == "8.8.8.8,8.8.4.4"
     assert os.environ["_APPSIGNAL_ENABLE_HOST_METRICS"] == "true"
     assert os.environ["_APPSIGNAL_ENABLE_NGINX_METRICS"] == "false"


### PR DESCRIPTION
Don't set the default certs file yet. That's part of issue #30. This
just adds the config option in case anyone wants to override it. The
agent will listen to it.

[skip changeset]
Part of #16
