### PR TITLE
Add log_path config option

### DIFF
--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -109,15 +109,19 @@ DEFAULT_CONFIG = Options(
 
 
 def log_file_path(config: Options) -> Optional[str]:
-    filename = "appsignal.log"
     path = config.get("log_path")
 
-    if path and not os.access(path, os.W_OK):
-        path = None
-        print(
-            f"appsignal: Unable to write to configured '{path}'. Please check the "
-            "permissions of the 'log_path' directory."
-        )
+    if path:
+        _, ext = os.path.splitext(path)
+        if ext:
+            path = os.path.dirname(path)
+
+        if not os.access(path, os.W_OK):
+            path = None
+            print(
+                f"appsignal: Unable to write to configured '{path}'. Please check the "
+                "permissions of the 'log_path' directory."
+            )
 
     if not path:
         path = "/tmp" if platform.system() == "Darwin" else tempfile.gettempdir()
@@ -128,8 +132,7 @@ def log_file_path(config: Options) -> Optional[str]:
             "permissions of the 'log_path' directory."
         )
         return None
-
-    return "/".join([path, filename])
+    return os.path.join(path, "appsignal.log")
 
 
 def from_system() -> Options:

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 from .__about__ import __version__
 
 import os
+import platform
+import tempfile
 from typing import cast, get_args, TypedDict, Union, Optional, Literal
 
 DefaultInstrumentation = Literal[
@@ -110,7 +112,6 @@ def log_file_path(config: Options) -> Optional[str]:
     filename = "appsignal.log"
     path = config.get("log_path")
 
-    print(f"!!!path {path}")
     if path and not os.access(path, os.W_OK):
         path = None
         print(
@@ -119,7 +120,7 @@ def log_file_path(config: Options) -> Optional[str]:
         )
 
     if not path:
-        path = "/tmp"
+        path = "/tmp" if platform.system() == "Darwin" else tempfile.gettempdir()
 
     if not os.access(path, os.W_OK):
         print(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -195,6 +195,15 @@ def test_set_private_environ_valid_log_path():
     assert os.environ["_APPSIGNAL_LOG_FILE_PATH"] == f"{cwdir}/appsignal.log"
 
 
+def test_set_private_environ_remove_filename_from_log_path():
+    cwdir = os.getcwd()
+    log_path = os.path.join(cwdir, "test.log")
+    config = Options(log_path=log_path)
+    set_private_environ(config)
+
+    assert os.environ["_APPSIGNAL_LOG_FILE_PATH"] == f"{cwdir}/appsignal.log"
+
+
 def test_set_private_environ_invalid_log_path():
     config = Options(log_path="/i_dont_exist")
     set_private_environ(config)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,6 +33,7 @@ def test_from_public_environ():
     os.environ["APPSIGNAL_IGNORE_ERRORS"] = "error1,error2"
     os.environ["APPSIGNAL_IGNORE_NAMESPACES"] = "namespace1,namespace2"
     os.environ["APPSIGNAL_LOG_LEVEL"] = "trace"
+    os.environ["APPSIGNAL_LOG_PATH"] = "/path/to/log_dir"
     os.environ["APPSIGNAL_PUSH_API_KEY"] = "some-api-key"
     os.environ["APPSIGNAL_PUSH_API_ENDPOINT"] = "https://push.appsignal.com"
     os.environ["APPSIGNAL_RUNNING_IN_CONTAINER"] = "true"
@@ -62,6 +63,7 @@ def test_from_public_environ():
         ignore_errors=["error1", "error2"],
         ignore_namespaces=["namespace1", "namespace2"],
         log_level="trace",
+        log_path="/path/to/log_dir",
         name="MyApp",
         push_api_key="some-api-key",
         revision="abc123",
@@ -120,6 +122,7 @@ def test_from_public_environ_disable_default_instrumentations_bool():
 
 
 def test_set_private_environ():
+    cwdir = os.getcwd()
     config = Options(
         active=True,
         app_path="/path/to/app",
@@ -139,6 +142,7 @@ def test_set_private_environ():
         ignore_errors=["error1", "error2"],
         ignore_namespaces=["namespace1", "namespace2"],
         log_level="trace",
+        log_path=cwdir,
         name="MyApp",
         push_api_key="some-api-key",
         revision="abc123",
@@ -169,6 +173,7 @@ def test_set_private_environ():
     assert os.environ["_APPSIGNAL_IGNORE_ERRORS"] == "error1,error2"
     assert os.environ["_APPSIGNAL_IGNORE_NAMESPACES"] == "namespace1,namespace2"
     assert os.environ["_APPSIGNAL_LOG_LEVEL"] == "trace"
+    assert os.environ["_APPSIGNAL_LOG_FILE_PATH"] == f"{cwdir}/appsignal.log"
     assert os.environ["_APPSIGNAL_PUSH_API_KEY"] == "some-api-key"
     assert os.environ["_APPSIGNAL_PUSH_API_ENDPOINT"] == "https://push.appsignal.com"
     assert (
@@ -180,6 +185,21 @@ def test_set_private_environ():
     assert os.environ["_APPSIGNAL_SEND_SESSION_DATA"] == "true"
     assert os.environ["_APPSIGNAL_WORKING_DIRECTORY_PATH"] == "/path/to/working/dir"
     assert os.environ["_APP_REVISION"] == "abc123"
+
+
+def test_set_private_environ_valid_log_path():
+    cwdir = os.getcwd()
+    config = Options(log_path=cwdir)
+    set_private_environ(config)
+
+    assert os.environ["_APPSIGNAL_LOG_FILE_PATH"] == f"{cwdir}/appsignal.log"
+
+
+def test_set_private_environ_invalid_log_path():
+    config = Options(log_path="/i_dont_exist")
+    set_private_environ(config)
+
+    assert os.environ["_APPSIGNAL_LOG_FILE_PATH"] == "/tmp/appsignal.log"
 
 
 def test_set_private_environ_bool_is_none():


### PR DESCRIPTION
﻿## Add log_path config option

Check if the specified path is writable or not, and if not, fall back on the system tmp dir.

It just prints the warning and doesn't log it. We don't have an internal logger yet, see issue #34. It will also need to log it eventually.

While discussing this implementation, we decided we want to refactor this so there's a Config class that handles all the function calls, so that we don't need to call `validate` manually this way in the future. See issue #36. So I'm leaving a proper validation "state" in the Config for that issue.

[skip changeset] Part of #16

## Fetch tmp dir in a cross platform way

Use the `gettempdir` method to fetch the system tmp dir. This won't work on macOS the way we want to, because it will create a new tmp dir every time and we want it to point to `/tmp`.
