### PR TITLE
Implement install command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-sdk",
   "opentelemetry-exporter-otlp-proto-http",
+  "docopt",
 ]
 dynamic = ["version"]
 
@@ -52,6 +53,7 @@ artifacts = ["src/appsignal/appsignal-agent"]
 dependencies = [
   "pytest",
   "pytest-cov",
+  "pytest-mock",
 ]
 [tool.hatch.envs.default.scripts]
 cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=src --cov=tests {args}"
@@ -70,6 +72,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-sdk",
   "opentelemetry-exporter-otlp-proto-http",
+  "docopt",
 ]
 
 [tool.hatch.envs.lint.scripts]

--- a/src/appsignal/cli.py
+++ b/src/appsignal/cli.py
@@ -65,15 +65,33 @@ class InstallCommand(CLICommand):
         self._name = None
 
     def run(self) -> int:
-        print("Welcome to the AppSignal for Python installer!")
+        print("👋 Welcome to the AppSignal for Python installer!")
+        print()
+        print("Reach us at support@appsignal.com for support")
+        print("Documentation available at https://docs.appsignal.com/python")
+        print()
+
         self._input_name()
 
         if self._push_api_key is None:
             self._input_push_api_key()
 
+        print()
+
         if self._should_write_file():
             print(f"Writing the {INSTALL_FILE_NAME} configuration file...")
             self._write_file()
+            print()
+            print("✅ Done! AppSignal for Python has now been installed.")
+            print()
+            print(
+                "To start AppSignal in your application, add the following code to your"
+            )
+            print("application's entrypoint:")
+            print()
+            print("    from __appsignal__ import appsignal")
+            print("    appsignal.start()")
+            print()
         else:
             print("Nothing to do. Exiting...")
 

--- a/src/appsignal/cli.py
+++ b/src/appsignal/cli.py
@@ -1,2 +1,118 @@
+from abc import ABC, abstractmethod
+import os
+
+from typing import Optional
+from docopt import docopt
+
+from .__about__ import __version__
+
+DOC = """AppSignal for Python CLI.
+
+Usage:
+  appsignal install [--push-api-key=<key>]
+  appsignal (-h | --help)
+  appsignal --version
+
+Options:
+  -h --help             Show this screen and exit.
+  --version             Show version number and exit.
+  --push-api-key=<key>  Push API Key to use for the installation.
+"""
+
+
 def run():
-    print("Hello AppSignal!")
+    version = f"AppSignal for Python v{__version__}"
+
+    arguments = docopt(DOC, version=version)
+
+    return command_for(arguments).run()
+
+
+class CLICommand(ABC):
+    @abstractmethod
+    def run(self) -> int:
+        raise NotImplementedError
+
+
+def command_for(arguments) -> CLICommand:
+    if arguments["install"]:
+        return InstallCommand(push_api_key=arguments["--push-api-key"])
+    else:
+        raise NotImplementedError
+
+
+INSTALL_FILE_TEMPLATE = """from appsignal import Appsignal
+
+appsignal = Appsignal(
+    active=True,
+    name="{name}",
+    push_api_key="{push_api_key}",
+    environment="development",
+)
+"""
+
+INSTALL_FILE_NAME = "appsignal_config.py"
+INSTALL_FILE_PATH = f"{os.getcwd()}/{INSTALL_FILE_NAME}"
+
+
+class InstallCommand(CLICommand):
+    _push_api_key: Optional[str]
+    _name: Optional[str]
+
+    def __init__(self, push_api_key=None):
+        self._push_api_key = push_api_key
+        self._name = None
+
+    def run(self) -> int:
+        print("Welcome to the AppSignal for Python installer!")
+        self._input_name()
+
+        if self._push_api_key is None:
+            self._input_push_api_key()
+
+        if self._should_write_file():
+            print(f"Writing the {INSTALL_FILE_NAME} configuration file...")
+            self._write_file()
+        else:
+            print("Nothing to do. Exiting...")
+
+        return 0
+
+    def _should_write_file(self):
+        if os.path.exists(INSTALL_FILE_PATH):
+            return self._input_should_overwrite_file()
+        else:
+            return True
+
+    def _input_should_overwrite_file(self):
+        response = input(
+            f"The {INSTALL_FILE_NAME} file already exists."
+            " Should it be overwritten? (y/N): "
+        )
+        if len(response) == 0 or response[0].lower() == "n":
+            return False
+        elif response[0].lower() == "y":
+            return True
+        else:
+            print('Please answer "y" (yes) or "n" (no)')
+            return self._input_should_overwrite_file()
+
+    def _input_push_api_key(self):
+        key = input("Please enter your Push API key: ")
+        self._push_api_key = key
+        if self._push_api_key == "":
+            self._input_push_api_key()
+
+    def _input_name(self):
+        self._name = input("Please enter the name of your application: ")
+        if self._name == "":
+            self._input_name()
+
+    def _write_file(self):
+        with open(INSTALL_FILE_PATH, "w") as f:
+            file_contents = INSTALL_FILE_TEMPLATE.format(
+                name=self._name,
+                push_api_key=self._push_api_key,
+            )
+
+            f.write(file_contents)

--- a/src/appsignal/cli.py
+++ b/src/appsignal/cli.py
@@ -47,7 +47,6 @@ appsignal = Appsignal(
     active=True,
     name="{name}",
     push_api_key="{push_api_key}",
-    environment="development",
 )
 """
 

--- a/src/appsignal/cli.py
+++ b/src/appsignal/cli.py
@@ -51,8 +51,7 @@ appsignal = Appsignal(
 )
 """
 
-INSTALL_FILE_NAME = "appsignal_config.py"
-INSTALL_FILE_PATH = f"{os.getcwd()}/{INSTALL_FILE_NAME}"
+INSTALL_FILE_NAME = "__appsignal__.py"
 
 
 class InstallCommand(CLICommand):
@@ -79,7 +78,7 @@ class InstallCommand(CLICommand):
         return 0
 
     def _should_write_file(self):
-        if os.path.exists(INSTALL_FILE_PATH):
+        if os.path.exists(INSTALL_FILE_NAME):
             return self._input_should_overwrite_file()
         else:
             return True
@@ -109,7 +108,7 @@ class InstallCommand(CLICommand):
             self._input_name()
 
     def _write_file(self):
-        with open(INSTALL_FILE_PATH, "w") as f:
+        with open(INSTALL_FILE_NAME, "w") as f:
             file_contents = INSTALL_FILE_TEMPLATE.format(
                 name=self._name,
                 push_api_key=self._push_api_key,

--- a/src/appsignal/cli.py
+++ b/src/appsignal/cli.py
@@ -21,11 +21,14 @@ Options:
 
 
 def run():
-    version = f"AppSignal for Python v{__version__}"
+    try:
+        version = f"AppSignal for Python v{__version__}"
 
-    arguments = docopt(DOC, version=version)
+        arguments = docopt(DOC, version=version)
 
-    return command_for(arguments).run()
+        return command_for(arguments).run()
+    except KeyboardInterrupt:
+        return 0
 
 
 class CLICommand(ABC):

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -106,6 +106,7 @@ DEFAULT_CONFIG = Options(
     enable_nginx_metrics=False,
     enable_statsd=False,
     endpoint="https://push.appsignal.com",
+    environment="development",
     files_world_accessible=True,
     send_environment_metadata=True,
     send_params=True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,6 @@ appsignal = Appsignal(
     active=True,
     name="My app name",
     push_api_key="My push API key",
-    environment="development",
 )
 """
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,138 @@
+from contextlib import contextmanager
+import builtins
+
+from typing import cast
+from unittest.mock import MagicMock
+
+EXPECTED_FILE_CONTENTS = """from appsignal import Appsignal
+
+appsignal = Appsignal(
+    active=True,
+    name="My app name",
+    push_api_key="My push API key",
+    environment="development",
+)
+"""
+
+
+@contextmanager
+def mock_input(mocker, pairs):
+    prompt_calls = [mocker.call(prompt) for (prompt, _) in pairs]
+    answers = [answer for (_, answer) in pairs]
+
+    mocker.patch("builtins.input", side_effect=answers)
+
+    yield
+
+    assert prompt_calls == cast(MagicMock, builtins.input).mock_calls
+
+
+def mock_file_operations(mocker, file_exists=False):
+    mocker.patch("os.path.exists", return_value=file_exists)
+    mocker.patch("os.getcwd", return_value="/app")
+    mocker.patch("builtins.open")
+
+
+def assert_wrote_file_contents(mocker):
+    builtins_open = cast(MagicMock, builtins.open)
+    assert mocker.call("/app/appsignal_config.py", "w") in builtins_open.mock_calls
+    assert (
+        mocker.call().__enter__().write(EXPECTED_FILE_CONTENTS)
+        in builtins_open.mock_calls
+    )
+
+
+def test_install_command_run(mocker):
+    mock_file_operations(mocker)
+
+    with mock_input(
+        mocker,
+        [
+            ("Please enter the name of your application: ", "My app name"),
+            ("Please enter your Push API key: ", "My push API key"),
+        ],
+    ):
+        from appsignal.cli import InstallCommand
+
+        InstallCommand().run()
+
+    assert_wrote_file_contents(mocker)
+
+
+def test_install_command_when_empty_value_ask_again(mocker):
+    mock_file_operations(mocker)
+
+    with mock_input(
+        mocker,
+        [
+            ("Please enter the name of your application: ", ""),
+            ("Please enter the name of your application: ", "My app name"),
+            ("Please enter your Push API key: ", ""),
+            ("Please enter your Push API key: ", "My push API key"),
+        ],
+    ):
+        from appsignal.cli import InstallCommand
+
+        InstallCommand().run()
+
+    assert_wrote_file_contents(mocker)
+
+
+def test_install_command_when_push_api_key_given(mocker):
+    mock_file_operations(mocker)
+
+    with mock_input(
+        mocker,
+        [
+            ("Please enter the name of your application: ", "My app name"),
+        ],
+    ):
+        from appsignal.cli import InstallCommand
+
+        InstallCommand(push_api_key="My push API key").run()
+
+    assert_wrote_file_contents(mocker)
+
+
+def test_install_command_when_file_exists_overwrite(mocker):
+    mock_file_operations(mocker, file_exists=True)
+
+    with mock_input(
+        mocker,
+        [
+            ("Please enter the name of your application: ", "My app name"),
+            ("Please enter your Push API key: ", "My push API key"),
+            (
+                "The appsignal_config.py file already exists."
+                " Should it be overwritten? (y/N): ",
+                "y",
+            ),
+        ],
+    ):
+        from appsignal.cli import InstallCommand
+
+        InstallCommand().run()
+
+    assert_wrote_file_contents(mocker)
+
+
+def test_install_command_when_file_exists_no_overwrite(mocker):
+    mock_file_operations(mocker, file_exists=True)
+
+    with mock_input(
+        mocker,
+        [
+            ("Please enter the name of your application: ", "My app name"),
+            ("Please enter your Push API key: ", "My push API key"),
+            (
+                "The appsignal_config.py file already exists."
+                " Should it be overwritten? (y/N): ",
+                "n",
+            ),
+        ],
+    ):
+        from appsignal.cli import InstallCommand
+
+        InstallCommand().run()
+
+    assert [] == cast(MagicMock, builtins.open).mock_calls

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,13 +29,12 @@ def mock_input(mocker, pairs):
 
 def mock_file_operations(mocker, file_exists=False):
     mocker.patch("os.path.exists", return_value=file_exists)
-    mocker.patch("os.getcwd", return_value="/app")
     mocker.patch("builtins.open")
 
 
 def assert_wrote_file_contents(mocker):
     builtins_open = cast(MagicMock, builtins.open)
-    assert mocker.call("/app/appsignal_config.py", "w") in builtins_open.mock_calls
+    assert mocker.call("__appsignal__.py", "w") in builtins_open.mock_calls
     assert (
         mocker.call().__enter__().write(EXPECTED_FILE_CONTENTS)
         in builtins_open.mock_calls
@@ -103,7 +102,7 @@ def test_install_command_when_file_exists_overwrite(mocker):
             ("Please enter the name of your application: ", "My app name"),
             ("Please enter your Push API key: ", "My push API key"),
             (
-                "The appsignal_config.py file already exists."
+                "The __appsignal__.py file already exists."
                 " Should it be overwritten? (y/N): ",
                 "y",
             ),
@@ -125,7 +124,7 @@ def test_install_command_when_file_exists_no_overwrite(mocker):
             ("Please enter the name of your application: ", "My app name"),
             ("Please enter your Push API key: ", "My push API key"),
             (
-                "The appsignal_config.py file already exists."
+                "The __appsignal__.py file already exists."
                 " Should it be overwritten? (y/N): ",
                 "n",
             ),


### PR DESCRIPTION
Implement an installation command that asks the user to input the necessary information to generate an `appsignal_config.py` file.

Closes #18. [skip changeset]

The installer is functional, but it's missing "flair" -- emojis, links to the docs, friendliness, that sort of stuff. Suggestions welcome. I could also just copy what some other integration's installer does.