### PR TITLE
Refactor config into Config class

### DIFF
--- a/src/appsignal/agent.py
+++ b/src/appsignal/agent.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import os
 import subprocess
 
-from .config import Options, set_private_environ
+from .config import Config
 
 AGENT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "appsignal-agent")
 
 
-def start_agent(config: Options):
-    set_private_environ(config)
+def start_agent(config: Config):
+    config.set_private_environ()
 
     subprocess.Popen([AGENT_PATH, "start", "--private"])

--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -1,21 +1,20 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 from .agent import start_agent
-from .config import DEFAULT_CONFIG, from_system, from_public_environ
 from .opentelemetry import start_opentelemetry
+from .config import Config, Options
 
 if TYPE_CHECKING:
     from typing import Unpack
-    from .config import Options
 
 
 class Client:
-    _options: Options
+    _config: Config
 
     def __init__(self, **options: Unpack[Options]):
-        self._options = DEFAULT_CONFIG | from_system() | options | from_public_environ()
+        self._config = Config(options)
 
     def start(self):
-        if self._options.get("active"):
-            start_agent(self._options)
-            start_opentelemetry(self._options)
+        if self._config.options.get("active"):
+            start_agent(self._config)
+            start_opentelemetry(self._config)

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -4,62 +4,10 @@ from .__about__ import __version__
 import os
 import platform
 import tempfile
-from typing import cast, get_args, TypedDict, Union, Optional, Literal
+from typing import TYPE_CHECKING, cast, get_args, TypedDict, Union, Optional, Literal
 
-DefaultInstrumentation = Literal[
-    "opentelemetry.instrumentation.celery",
-    "opentelemetry.instrumentation.django",
-    "opentelemetry.instrumentation.jinja2",
-    "opentelemetry.instrumentation.psycopg2",
-    "opentelemetry.instrumentation.redis",
-    "opentelemetry.instrumentation.requests",
-]
-
-DEFAULT_INSTRUMENTATIONS = cast(
-    list[DefaultInstrumentation], list(get_args(DefaultInstrumentation))
-)
-
-CONSTANT_PRIVATE_ENVIRON = {
-    "_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION": f"python-{__version__}",
-    "_APPSIGNAL_ENABLE_OPENTELEMETRY_HTTP": "true",
-}
-
-
-def parse_bool(value: Optional[str]) -> Optional[bool]:
-    if value is None:
-        return None
-
-    val = value.lower()
-    if val == "true":
-        return True
-    if val == "false":
-        return False
-
-    return None
-
-
-def parse_list(value: Optional[str]) -> Optional[list[str]]:
-    if value is None:
-        return None
-
-    return value.split(",")
-
-
-def parse_disable_default_instrumentations(
-    value: Optional[str],
-) -> Optional[Union[list[DefaultInstrumentation], bool]]:
-    if value is None:
-        return None
-
-    if value.lower() == "true":
-        return True
-    if value.lower() == "false":
-        return False
-
-    return cast(
-        list[DefaultInstrumentation],
-        [x for x in value.split(",") if x in DEFAULT_INSTRUMENTATIONS],
-    )
+if TYPE_CHECKING:
+    pass
 
 
 class Options(TypedDict, total=False):
@@ -67,7 +15,7 @@ class Options(TypedDict, total=False):
     app_path: Optional[str]
     ca_file_path: Optional[str]
     disable_default_instrumentations: Optional[
-        Union[list[DefaultInstrumentation], bool]
+        Union[list[Config.DefaultInstrumentation], bool]
     ]
     dns_servers: Optional[list[str]]
     enable_host_metrics: Optional[bool]
@@ -96,101 +44,219 @@ class Options(TypedDict, total=False):
     working_directory_path: Optional[str]
 
 
-CA_FILE_PATH = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "resources", "cacert.pem"
-)
-
-DEFAULT_CONFIG = Options(
-    ca_file_path=CA_FILE_PATH,
-    enable_host_metrics=True,
-    enable_nginx_metrics=False,
-    enable_statsd=False,
-    endpoint="https://push.appsignal.com",
-    environment="development",
-    files_world_accessible=True,
-    send_environment_metadata=True,
-    send_params=True,
-    send_session_data=True,
-)
-
-
-def log_file_path(config: Options) -> Optional[str]:
-    path = config.get("log_path")
-
-    if path:
-        _, ext = os.path.splitext(path)
-        if ext:
-            path = os.path.dirname(path)
-
-        if not os.access(path, os.W_OK):
-            path = None
-            print(
-                f"appsignal: Unable to write to configured '{path}'. Please check the "
-                "permissions of the 'log_path' directory."
-            )
-
-    if not path:
-        path = "/tmp" if platform.system() == "Darwin" else tempfile.gettempdir()
-
-    if not os.access(path, os.W_OK):
-        print(
-            f"appsignal: Unable to write to '{path}'. Please check the "
-            "permissions of the 'log_path' directory."
-        )
-        return None
-    return os.path.join(path, "appsignal.log")
-
-
-def from_system() -> Options:
-    return Options(app_path=os.getcwd())
-
-
-def from_public_environ() -> Options:
-    config = Options(
-        active=parse_bool(os.environ.get("APPSIGNAL_ACTIVE")),
-        ca_file_path=os.environ.get("APPSIGNAL_CA_FILE_PATH"),
-        disable_default_instrumentations=parse_disable_default_instrumentations(
-            os.environ.get("APPSIGNAL_DISABLE_DEFAULT_INSTRUMENTATIONS")
-        ),
-        dns_servers=parse_list(os.environ.get("APPSIGNAL_DNS_SERVERS")),
-        enable_host_metrics=parse_bool(os.environ.get("APPSIGNAL_ENABLE_HOST_METRICS")),
-        enable_nginx_metrics=parse_bool(
-            os.environ.get("APPSIGNAL_ENABLE_NGINX_METRICS")
-        ),
-        enable_statsd=parse_bool(os.environ.get("APPSIGNAL_ENABLE_STATSD")),
-        endpoint=os.environ.get("APPSIGNAL_PUSH_API_ENDPOINT"),
-        environment=os.environ.get("APPSIGNAL_APP_ENV"),
-        files_world_accessible=parse_bool(
-            os.environ.get("APPSIGNAL_FILES_WORLD_ACCESSIBLE")
-        ),
-        filter_parameters=parse_list(os.environ.get("APPSIGNAL_FILTER_PARAMETERS")),
-        filter_session_data=parse_list(os.environ.get("APPSIGNAL_FILTER_SESSION_DATA")),
-        hostname=os.environ.get("APPSIGNAL_HOSTNAME"),
-        http_proxy=os.environ.get("APPSIGNAL_HTTP_PROXY"),
-        ignore_actions=parse_list(os.environ.get("APPSIGNAL_IGNORE_ACTIONS")),
-        ignore_errors=parse_list(os.environ.get("APPSIGNAL_IGNORE_ERRORS")),
-        ignore_namespaces=parse_list(os.environ.get("APPSIGNAL_IGNORE_NAMESPACES")),
-        log_level=os.environ.get("APPSIGNAL_LOG_LEVEL"),
-        log_path=os.environ.get("APPSIGNAL_LOG_PATH"),
-        name=os.environ.get("APPSIGNAL_APP_NAME"),
-        push_api_key=os.environ.get("APPSIGNAL_PUSH_API_KEY"),
-        revision=os.environ.get("APP_REVISION"),
-        running_in_container=parse_bool(
-            os.environ.get("APPSIGNAL_RUNNING_IN_CONTAINER")
-        ),
-        send_environment_metadata=parse_bool(
-            os.environ.get("APPSIGNAL_SEND_ENVIRONMENT_METADATA")
-        ),
-        send_params=parse_bool(os.environ.get("APPSIGNAL_SEND_PARAMS")),
-        send_session_data=parse_bool(os.environ.get("APPSIGNAL_SEND_SESSION_DATA")),
-        working_directory_path=os.environ.get("APPSIGNAL_WORKING_DIRECTORY_PATH"),
+class Config:
+    CA_FILE_PATH = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "resources", "cacert.pem"
+    )
+    DEFAULT_CONFIG = Options(
+        ca_file_path=CA_FILE_PATH,
+        enable_host_metrics=True,
+        enable_nginx_metrics=False,
+        enable_statsd=False,
+        environment="development",
+        endpoint="https://push.appsignal.com",
+        files_world_accessible=True,
+        send_environment_metadata=True,
+        send_params=True,
+        send_session_data=True,
     )
 
-    for key, value in list(config.items()):
-        if value is None:
-            del cast(dict, config)[key]
+    DefaultInstrumentation = Literal[
+        "opentelemetry.instrumentation.celery",
+        "opentelemetry.instrumentation.django",
+        "opentelemetry.instrumentation.jinja2",
+        "opentelemetry.instrumentation.psycopg2",
+        "opentelemetry.instrumentation.redis",
+        "opentelemetry.instrumentation.requests",
+    ]
+    DEFAULT_INSTRUMENTATIONS = cast(
+        list[DefaultInstrumentation], list(get_args(DefaultInstrumentation))
+    )
 
-    return config
+    def __init__(self, options: Optional[Options]):
+        self.initial_source = options
+        self.system_source = self.load_from_system()
+        self.environment_source = self.load_from_environment()
+        self.options = self.DEFAULT_CONFIG | self.system_source
+        if self.initial_source:
+            self.options = self.options | self.initial_source
+        self.options = self.options | self.environment_source
+
+    def load_from_system(self) -> Options:
+        return Options(app_path=os.getcwd())
+
+    def load_from_environment(self) -> Options:
+        options = Options(
+            active=parse_bool(os.environ.get("APPSIGNAL_ACTIVE")),
+            ca_file_path=os.environ.get("APPSIGNAL_CA_FILE_PATH"),
+            disable_default_instrumentations=parse_disable_default_instrumentations(
+                os.environ.get("APPSIGNAL_DISABLE_DEFAULT_INSTRUMENTATIONS")
+            ),
+            dns_servers=parse_list(os.environ.get("APPSIGNAL_DNS_SERVERS")),
+            enable_host_metrics=parse_bool(
+                os.environ.get("APPSIGNAL_ENABLE_HOST_METRICS")
+            ),
+            enable_nginx_metrics=parse_bool(
+                os.environ.get("APPSIGNAL_ENABLE_NGINX_METRICS")
+            ),
+            enable_statsd=parse_bool(os.environ.get("APPSIGNAL_ENABLE_STATSD")),
+            endpoint=os.environ.get("APPSIGNAL_PUSH_API_ENDPOINT"),
+            environment=os.environ.get("APPSIGNAL_APP_ENV"),
+            files_world_accessible=parse_bool(
+                os.environ.get("APPSIGNAL_FILES_WORLD_ACCESSIBLE")
+            ),
+            filter_parameters=parse_list(os.environ.get("APPSIGNAL_FILTER_PARAMETERS")),
+            filter_session_data=parse_list(
+                os.environ.get("APPSIGNAL_FILTER_SESSION_DATA")
+            ),
+            hostname=os.environ.get("APPSIGNAL_HOSTNAME"),
+            http_proxy=os.environ.get("APPSIGNAL_HTTP_PROXY"),
+            ignore_actions=parse_list(os.environ.get("APPSIGNAL_IGNORE_ACTIONS")),
+            ignore_errors=parse_list(os.environ.get("APPSIGNAL_IGNORE_ERRORS")),
+            ignore_namespaces=parse_list(os.environ.get("APPSIGNAL_IGNORE_NAMESPACES")),
+            log_level=os.environ.get("APPSIGNAL_LOG_LEVEL"),
+            log_path=os.environ.get("APPSIGNAL_LOG_PATH"),
+            name=os.environ.get("APPSIGNAL_APP_NAME"),
+            push_api_key=os.environ.get("APPSIGNAL_PUSH_API_KEY"),
+            revision=os.environ.get("APP_REVISION"),
+            running_in_container=parse_bool(
+                os.environ.get("APPSIGNAL_RUNNING_IN_CONTAINER")
+            ),
+            send_environment_metadata=parse_bool(
+                os.environ.get("APPSIGNAL_SEND_ENVIRONMENT_METADATA")
+            ),
+            send_params=parse_bool(os.environ.get("APPSIGNAL_SEND_PARAMS")),
+            send_session_data=parse_bool(os.environ.get("APPSIGNAL_SEND_SESSION_DATA")),
+            working_directory_path=os.environ.get("APPSIGNAL_WORKING_DIRECTORY_PATH"),
+        )
+
+        for key, value in list(options.items()):
+            if value is None:
+                del cast(dict, options)[key]
+
+        return options
+
+    CONSTANT_PRIVATE_ENVIRON = {
+        "_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION": f"python-{__version__}",
+        "_APPSIGNAL_ENABLE_OPENTELEMETRY_HTTP": "true",
+    }
+
+    def set_private_environ(self):
+        options = self.options
+        private_environ = {
+            "_APPSIGNAL_ACTIVE": bool_to_env_str(options.get("active")),
+            "_APPSIGNAL_APP_ENV": options.get("environment"),
+            "_APPSIGNAL_APP_NAME": options.get("name"),
+            "_APPSIGNAL_APP_PATH": options.get("app_path"),
+            "_APPSIGNAL_CA_FILE_PATH": options.get("ca_file_path"),
+            "_APPSIGNAL_DNS_SERVERS": list_to_env_str(options.get("dns_servers")),
+            "_APPSIGNAL_ENABLE_HOST_METRICS": bool_to_env_str(
+                options.get("enable_host_metrics")
+            ),
+            "_APPSIGNAL_ENABLE_NGINX_METRICS": bool_to_env_str(
+                options.get("enable_nginx_metrics")
+            ),
+            "_APPSIGNAL_ENABLE_STATSD": bool_to_env_str(options.get("enable_statsd")),
+            "_APPSIGNAL_FILES_WORLD_ACCESSIBLE": bool_to_env_str(
+                options.get("files_world_accessible")
+            ),
+            "_APPSIGNAL_FILTER_PARAMETERS": list_to_env_str(
+                options.get("filter_parameters")
+            ),
+            "_APPSIGNAL_FILTER_SESSION_DATA": list_to_env_str(
+                options.get("filter_session_data")
+            ),
+            "_APPSIGNAL_HOSTNAME": options.get("hostname"),
+            "_APPSIGNAL_HTTP_PROXY": options.get("http_proxy"),
+            "_APPSIGNAL_IGNORE_ACTIONS": list_to_env_str(options.get("ignore_actions")),
+            "_APPSIGNAL_IGNORE_ERRORS": list_to_env_str(options.get("ignore_errors")),
+            "_APPSIGNAL_IGNORE_NAMESPACES": list_to_env_str(
+                options.get("ignore_namespaces")
+            ),
+            "_APPSIGNAL_LOG_LEVEL": options.get("log_level"),
+            "_APPSIGNAL_LOG_FILE_PATH": self.log_file_path(),
+            "_APPSIGNAL_PUSH_API_KEY": options.get("push_api_key"),
+            "_APPSIGNAL_PUSH_API_ENDPOINT": options.get("endpoint"),
+            "_APPSIGNAL_RUNNING_IN_CONTAINER": bool_to_env_str(
+                options.get("running_in_container")
+            ),
+            "_APPSIGNAL_SEND_ENVIRONMENT_METADATA": bool_to_env_str(
+                options.get("send_environment_metadata")
+            ),
+            "_APPSIGNAL_SEND_PARAMS": bool_to_env_str(options.get("send_params")),
+            "_APPSIGNAL_SEND_SESSION_DATA": bool_to_env_str(
+                options.get("send_session_data")
+            ),
+            "_APPSIGNAL_WORKING_DIRECTORY_PATH": options.get("working_directory_path"),
+            "_APP_REVISION": options.get("revision"),
+        } | self.CONSTANT_PRIVATE_ENVIRON
+
+        for var, value in private_environ.items():
+            if value is not None:
+                os.environ[var] = str(value)
+
+    def log_file_path(self) -> Optional[str]:
+        path = self.options.get("log_path")
+
+        if path:
+            _, ext = os.path.splitext(path)
+            if ext:
+                path = os.path.dirname(path)
+
+            if not os.access(path, os.W_OK):
+                path = None
+                print(
+                    f"appsignal: Unable to write to configured '{path}'. Please "
+                    "check the permissions of the 'log_path' directory."
+                )
+
+        if not path:
+            path = "/tmp" if platform.system() == "Darwin" else tempfile.gettempdir()
+
+        if not os.access(path, os.W_OK):
+            print(
+                f"appsignal: Unable to write to '{path}'. Please check the "
+                "permissions of the 'log_path' directory."
+            )
+            return None
+        return os.path.join(path, "appsignal.log")
+
+
+def parse_bool(value: Optional[str]) -> Optional[bool]:
+    if value is None:
+        return None
+
+    val = value.lower()
+    if val == "true":
+        return True
+    if val == "false":
+        return False
+
+    return None
+
+
+def parse_list(value: Optional[str]) -> Optional[list[str]]:
+    if value is None:
+        return None
+
+    return value.split(",")
+
+
+def parse_disable_default_instrumentations(
+    value: Optional[str],
+) -> Optional[Union[list[Config.DefaultInstrumentation], bool]]:
+    if value is None:
+        return None
+
+    if value.lower() == "true":
+        return True
+    if value.lower() == "false":
+        return False
+
+    return cast(
+        list[Config.DefaultInstrumentation],
+        [x for x in value.split(",") if x in Config.DEFAULT_INSTRUMENTATIONS],
+    )
 
 
 def bool_to_env_str(value: Optional[bool]):
@@ -205,57 +271,3 @@ def list_to_env_str(value: Optional[list[str]]):
         return None
 
     return ",".join(value)
-
-
-def set_private_environ(config: Options):
-    private_environ = {
-        "_APPSIGNAL_ACTIVE": bool_to_env_str(config.get("active")),
-        "_APPSIGNAL_APP_ENV": config.get("environment"),
-        "_APPSIGNAL_APP_NAME": config.get("name"),
-        "_APPSIGNAL_APP_PATH": config.get("app_path"),
-        "_APPSIGNAL_CA_FILE_PATH": config.get("ca_file_path"),
-        "_APPSIGNAL_DNS_SERVERS": list_to_env_str(config.get("dns_servers")),
-        "_APPSIGNAL_ENABLE_HOST_METRICS": bool_to_env_str(
-            config.get("enable_host_metrics")
-        ),
-        "_APPSIGNAL_ENABLE_NGINX_METRICS": bool_to_env_str(
-            config.get("enable_nginx_metrics")
-        ),
-        "_APPSIGNAL_ENABLE_STATSD": bool_to_env_str(config.get("enable_statsd")),
-        "_APPSIGNAL_FILES_WORLD_ACCESSIBLE": bool_to_env_str(
-            config.get("files_world_accessible")
-        ),
-        "_APPSIGNAL_FILTER_PARAMETERS": list_to_env_str(
-            config.get("filter_parameters")
-        ),
-        "_APPSIGNAL_FILTER_SESSION_DATA": list_to_env_str(
-            config.get("filter_session_data")
-        ),
-        "_APPSIGNAL_HOSTNAME": config.get("hostname"),
-        "_APPSIGNAL_HTTP_PROXY": config.get("http_proxy"),
-        "_APPSIGNAL_IGNORE_ACTIONS": list_to_env_str(config.get("ignore_actions")),
-        "_APPSIGNAL_IGNORE_ERRORS": list_to_env_str(config.get("ignore_errors")),
-        "_APPSIGNAL_IGNORE_NAMESPACES": list_to_env_str(
-            config.get("ignore_namespaces")
-        ),
-        "_APPSIGNAL_LOG_LEVEL": config.get("log_level"),
-        "_APPSIGNAL_LOG_FILE_PATH": log_file_path(config),
-        "_APPSIGNAL_PUSH_API_KEY": config.get("push_api_key"),
-        "_APPSIGNAL_PUSH_API_ENDPOINT": config.get("endpoint"),
-        "_APPSIGNAL_RUNNING_IN_CONTAINER": bool_to_env_str(
-            config.get("running_in_container")
-        ),
-        "_APPSIGNAL_SEND_ENVIRONMENT_METADATA": bool_to_env_str(
-            config.get("send_environment_metadata")
-        ),
-        "_APPSIGNAL_SEND_PARAMS": bool_to_env_str(config.get("send_params")),
-        "_APPSIGNAL_SEND_SESSION_DATA": bool_to_env_str(
-            config.get("send_session_data")
-        ),
-        "_APPSIGNAL_WORKING_DIRECTORY_PATH": config.get("working_directory_path"),
-        "_APP_REVISION": config.get("revision"),
-    } | CONSTANT_PRIVATE_ENVIRON
-
-    for var, value in private_environ.items():
-        if value is not None:
-            os.environ[var] = str(value)

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .config import Options, DefaultInstrumentation
+from .config import Config
 
 from typing import Callable
 
@@ -54,7 +54,9 @@ def add_requests_instrumentation():
 
 
 DefaultInstrumentationAdder = Callable[[], None]
-DefaultInstrumentationAdders = dict[DefaultInstrumentation, DefaultInstrumentationAdder]
+DefaultInstrumentationAdders = dict[
+    Config.DefaultInstrumentation, DefaultInstrumentationAdder
+]
 
 DEFAULT_INSTRUMENTATION_ADDERS: DefaultInstrumentationAdders = {
     "opentelemetry.instrumentation.celery": add_celery_instrumentation,
@@ -66,7 +68,7 @@ DEFAULT_INSTRUMENTATION_ADDERS: DefaultInstrumentationAdders = {
 }
 
 
-def start_opentelemetry(config: Options):
+def start_opentelemetry(config: Config):
     provider = TracerProvider()
 
     otlp_exporter = OTLPSpanExporter(endpoint="http://localhost:8099")
@@ -78,9 +80,9 @@ def start_opentelemetry(config: Options):
 
 
 def add_instrumentations(
-    config: Options, default_instrumentation_adders=DEFAULT_INSTRUMENTATION_ADDERS
+    config: Config, default_instrumentation_adders=DEFAULT_INSTRUMENTATION_ADDERS
 ):
-    disable_list = config.get("disable_default_instrumentations") or []
+    disable_list = config.options.get("disable_default_instrumentations") or []
 
     if disable_list is True:
         return

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,15 +6,15 @@ import os
 def test_client_options_merge_sources():
     os.environ["APPSIGNAL_PUSH_API_KEY"] = "some_key"
     client = Client(name="MyApp")
-    assert client._options["name"] == "MyApp"
-    assert client._options["push_api_key"] == "some_key"
-    assert "app_path" in client._options
+    assert client._config.options["name"] == "MyApp"
+    assert client._config.options["push_api_key"] == "some_key"
+    assert "app_path" in client._config.options
 
 
 def test_client_active():
     client = Client(active=True, name="MyApp")
-    assert client._options["active"] is True
-    assert client._options["name"] == "MyApp"
+    assert client._config.options["active"] is True
+    assert client._config.options["name"] == "MyApp"
     client.start()
 
     # Sets the private config environment variables
@@ -24,8 +24,8 @@ def test_client_active():
 
 def test_client_inactive():
     client = Client(active=False, name="MyApp")
-    assert client._options["active"] is False
-    assert client._options["name"] == "MyApp"
+    assert client._config.options["active"] is False
+    assert client._config.options["name"] == "MyApp"
     client.start()
 
     # Does not set the private config environment variables

--- a/tests/test_opentelemetry.py
+++ b/tests/test_opentelemetry.py
@@ -1,14 +1,14 @@
 from unittest.mock import Mock
 
-from appsignal.config import Options
-from appsignal.opentelemetry import add_instrumentations, DefaultInstrumentation
+from appsignal.config import Config, Options
+from appsignal.opentelemetry import add_instrumentations
 
 
 def raise_module_not_found_error():
     raise ModuleNotFoundError()
 
 
-def mock_adders() -> dict[DefaultInstrumentation, Mock]:
+def mock_adders() -> dict[Config.DefaultInstrumentation, Mock]:
     return {
         "opentelemetry.instrumentation.celery": Mock(),
         "opentelemetry.instrumentation.jinja2": Mock(
@@ -19,7 +19,7 @@ def mock_adders() -> dict[DefaultInstrumentation, Mock]:
 
 def test_add_instrumentations():
     adders = mock_adders()
-    config = Options()
+    config = Config(None)
 
     add_instrumentations(config, default_instrumentation_adders=adders)
 
@@ -29,8 +29,10 @@ def test_add_instrumentations():
 
 def test_add_instrumentations_disable_some_default_instrumentations():
     adders = mock_adders()
-    config = Options(
-        disable_default_instrumentations=["opentelemetry.instrumentation.celery"]
+    config = Config(
+        Options(
+            disable_default_instrumentations=["opentelemetry.instrumentation.celery"]
+        )
     )
 
     add_instrumentations(config, default_instrumentation_adders=adders)
@@ -41,7 +43,7 @@ def test_add_instrumentations_disable_some_default_instrumentations():
 
 def test_add_instrumentations_disable_all_default_instrumentations():
     adders = mock_adders()
-    config = Options(disable_default_instrumentations=True)
+    config = Config(Options(disable_default_instrumentations=True))
 
     add_instrumentations(config, default_instrumentation_adders=adders)
 


### PR DESCRIPTION
We had a bunch of different Options dict instances that we merged for multiple sources to create the config for the package.

This change merges all config into one class that keeps track of the config options, sources, and potential other state.

[skip changeset]
Needed for #19, to implement the diagnose report.
Closes #36