### PR TITLE
Config refactor part 2

### DIFF
--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -74,14 +74,17 @@ class Config:
     )
 
     def __init__(self, options: Optional[Options] = None):
-        self.initial_source = options or Options()
-        self.system_source = Config.load_from_system()
-        self.environment_source = Config.load_from_environment()
+        self.sources = dict(
+            default=self.DEFAULT_CONFIG,
+            system=Config.load_from_system(),
+            initial=options or Options(),
+            environment=Config.load_from_environment(),
+        )
         self.options = (
-            self.DEFAULT_CONFIG
-            | self.system_source
-            | self.initial_source
-            | self.environment_source
+            self.sources["default"]
+            | self.sources["system"]
+            | self.sources["initial"]
+            | self.sources["environment"]
         )
 
     @classmethod

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -73,14 +73,16 @@ class Config:
         list[DefaultInstrumentation], list(get_args(DefaultInstrumentation))
     )
 
-    def __init__(self, options: Optional[Options]):
-        self.initial_source = options
+    def __init__(self, options: Optional[Options] = None):
+        self.initial_source = options or Options()
         self.system_source = self.load_from_system()
         self.environment_source = self.load_from_environment()
-        self.options = self.DEFAULT_CONFIG | self.system_source
-        if self.initial_source:
-            self.options = self.options | self.initial_source
-        self.options = self.options | self.environment_source
+        self.options = (
+            self.DEFAULT_CONFIG
+            | self.system_source
+            | self.initial_source
+            | self.environment_source
+        )
 
     def load_from_system(self) -> Options:
         return Options(app_path=os.getcwd())

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -44,7 +44,16 @@ class Options(TypedDict, total=False):
     working_directory_path: Optional[str]
 
 
+class Sources(TypedDict):
+    default: Options
+    system: Options
+    initial: Options
+    environment: Options
+
+
 class Config:
+    sources: Sources
+
     CA_FILE_PATH = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "resources", "cacert.pem"
     )
@@ -74,7 +83,7 @@ class Config:
     )
 
     def __init__(self, options: Optional[Options] = None):
-        self.sources = dict(
+        self.sources = Sources(
             default=self.DEFAULT_CONFIG,
             system=Config.load_from_system(),
             initial=options or Options(),

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -75,8 +75,8 @@ class Config:
 
     def __init__(self, options: Optional[Options] = None):
         self.initial_source = options or Options()
-        self.system_source = self.load_from_system()
-        self.environment_source = self.load_from_environment()
+        self.system_source = Config.load_from_system()
+        self.environment_source = Config.load_from_environment()
         self.options = (
             self.DEFAULT_CONFIG
             | self.system_source
@@ -84,10 +84,12 @@ class Config:
             | self.environment_source
         )
 
-    def load_from_system(self) -> Options:
+    @classmethod
+    def load_from_system(_cls) -> Options:
         return Options(app_path=os.getcwd())
 
-    def load_from_environment(self) -> Options:
+    @classmethod
+    def load_from_environment(_cls) -> Options:
         options = Options(
             active=parse_bool(os.environ.get("APPSIGNAL_ACTIVE")),
             ca_file_path=os.environ.get("APPSIGNAL_CA_FILE_PATH"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ from appsignal.config import Config, Options
 
 
 def test_system_source():
-    config = Config(None)
+    config = Config()
 
     assert list(config.system_source.keys()) == ["app_path"]
     assert "app_path" in list(config.options.keys())
@@ -39,7 +39,7 @@ def test_environ_source():
     os.environ["APPSIGNAL_WORKING_DIRECTORY_PATH"] = "/path/to/working/dir"
     os.environ["APP_REVISION"] = "abc123"
 
-    config = Config(None)
+    config = Config()
 
     env_options = Options(
         active=True,
@@ -76,7 +76,7 @@ def test_environ_source():
 
 
 def test_environ_source_bool_is_unset():
-    config = Config(None)
+    config = Config()
 
     assert config.environment_source.get("active") is None
     assert config.options.get("active") is None
@@ -85,7 +85,7 @@ def test_environ_source_bool_is_unset():
 def test_environ_source_bool_is_empty_string():
     os.environ["APPSIGNAL_ACTIVE"] = ""
 
-    config = Config(None)
+    config = Config()
 
     assert config.environment_source.get("active") is None
     assert config.options.get("active") is None
@@ -94,7 +94,7 @@ def test_environ_source_bool_is_empty_string():
 def test_environ_source_bool_is_invalid():
     os.environ["APPSIGNAL_ACTIVE"] = "invalid"
 
-    config = Config(None)
+    config = Config()
 
     assert config.environment_source.get("active") is None
     assert config.options.get("active") is None
@@ -105,7 +105,7 @@ def test_environ_source_disable_default_instrumentations_list():
         ["opentelemetry.instrumentation.celery", "something.else"]
     )
 
-    config = Config(None)
+    config = Config()
 
     assert config.environment_source["disable_default_instrumentations"] == [
         "opentelemetry.instrumentation.celery"
@@ -123,7 +123,7 @@ def test_environ_source_disable_default_instrumentations_bool():
         ("false", False),
     ]:
         os.environ["APPSIGNAL_DISABLE_DEFAULT_INSTRUMENTATIONS"] = value
-        config = Config(None)
+        config = Config()
         assert config.options["disable_default_instrumentations"] is expected
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,7 @@ from appsignal.config import Config, Options
 def test_system_source():
     config = Config()
 
-    assert list(config.system_source.keys()) == ["app_path"]
+    assert list(config.sources["system"].keys()) == ["app_path"]
     assert "app_path" in list(config.options.keys())
 
 
@@ -69,16 +69,16 @@ def test_environ_source():
         send_session_data=True,
         working_directory_path="/path/to/working/dir",
     )
-    assert config.environment_source == env_options
+    assert config.sources["environment"] == env_options
     assert config.options == (
-        Config.DEFAULT_CONFIG | config.system_source | env_options
+        config.sources["default"] | config.sources["system"] | env_options
     )
 
 
 def test_environ_source_bool_is_unset():
     config = Config()
 
-    assert config.environment_source.get("active") is None
+    assert config.sources["environment"].get("active") is None
     assert config.options.get("active") is None
 
 
@@ -87,7 +87,7 @@ def test_environ_source_bool_is_empty_string():
 
     config = Config()
 
-    assert config.environment_source.get("active") is None
+    assert config.sources["environment"].get("active") is None
     assert config.options.get("active") is None
 
 
@@ -96,7 +96,7 @@ def test_environ_source_bool_is_invalid():
 
     config = Config()
 
-    assert config.environment_source.get("active") is None
+    assert config.sources["environment"].get("active") is None
     assert config.options.get("active") is None
 
 
@@ -107,7 +107,7 @@ def test_environ_source_disable_default_instrumentations_list():
 
     config = Config()
 
-    assert config.environment_source["disable_default_instrumentations"] == [
+    assert config.sources["environment"]["disable_default_instrumentations"] == [
         "opentelemetry.instrumentation.celery"
     ]
     assert config.options["disable_default_instrumentations"] == [

--- a/tests/test_opentelemetry.py
+++ b/tests/test_opentelemetry.py
@@ -19,7 +19,7 @@ def mock_adders() -> dict[Config.DefaultInstrumentation, Mock]:
 
 def test_add_instrumentations():
     adders = mock_adders()
-    config = Config(None)
+    config = Config()
 
     add_instrumentations(config, default_instrumentation_adders=adders)
 


### PR DESCRIPTION
## Set default options for Config initializer

No need to pass in `None` as an argument when no Options need to be set.

[skip changeset]

## Make `load_from_<source>` methods class methods

They don't need to know anything of the instance state currently, so let's leave it out.

## Move config sources to shared sources dictionary

Rather than assign separate fields on the Config class, store all different config sources on the same dictionary so it's easier to find back.
