### PR TITLE
Add internal logger

### DIFF
--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -14,7 +14,7 @@ class Client:
     _logger: Logger
     _config: Config
 
-    LOG_LEVELS = dict(error=ERROR, warning=WARNING, info=INFO, debug=DEBUG)
+    LOG_LEVELS = dict(error=ERROR, warning=WARNING, info=INFO, debug=DEBUG, trace=DEBUG)
 
     def __init__(self, **options: Unpack[Options]):
         self._config = Config(options)

--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
+import logging
+from logging import Logger, ERROR, WARNING, INFO, DEBUG
 from .agent import start_agent
 from .opentelemetry import start_opentelemetry
 from .config import Config, Options
@@ -9,12 +11,38 @@ if TYPE_CHECKING:
 
 
 class Client:
+    _logger: Logger
     _config: Config
+
+    LOG_LEVELS = dict(error=ERROR, warning=WARNING, info=INFO, debug=DEBUG)
 
     def __init__(self, **options: Unpack[Options]):
         self._config = Config(options)
+        self.start_logger()
+
+        if not self._config.option("active"):
+            self._logger.info("AppSignal not starting: no active config found")
 
     def start(self):
         if self._config.option("active"):
             start_agent(self._config)
             start_opentelemetry(self._config)
+
+    def start_logger(self):
+        log_file_path = self._config.log_file_path()
+        if log_file_path:
+            self._logger = logging.getLogger("appsignal")
+            handler = logging.FileHandler(log_file_path)
+            handler.setFormatter(
+                logging.Formatter(
+                    "[%(asctime)s (process) #%(process)d][%(levelname)s] %(message)s",
+                    "%Y-%m-%dT%H:%M:%S",
+                )
+            )
+            self._logger.addHandler(handler)
+            self._logger.setLevel(self.LOG_LEVELS[self._config.option("log_level")])
+        else:
+            print(
+                "[appsignal][ERROR] Could not initialize file logger. "
+                "Logger is inactive."
+            )

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -32,6 +32,7 @@ class Options(TypedDict, total=False):
     ignore_actions: Optional[list[str]]
     ignore_errors: Optional[list[str]]
     ignore_namespaces: Optional[list[str]]
+    log: Optional[str]
     log_level: Optional[str]
     log_path: Optional[str]
     name: Optional[str]
@@ -66,6 +67,8 @@ class Config:
         environment="development",
         endpoint="https://push.appsignal.com",
         files_world_accessible=True,
+        log="file",
+        log_level="info",
         send_environment_metadata=True,
         send_params=True,
         send_session_data=True,
@@ -144,6 +147,7 @@ class Config:
             ignore_actions=parse_list(os.environ.get("APPSIGNAL_IGNORE_ACTIONS")),
             ignore_errors=parse_list(os.environ.get("APPSIGNAL_IGNORE_ERRORS")),
             ignore_namespaces=parse_list(os.environ.get("APPSIGNAL_IGNORE_NAMESPACES")),
+            log=os.environ.get("APPSIGNAL_LOG"),
             log_level=os.environ.get("APPSIGNAL_LOG_LEVEL"),
             log_path=os.environ.get("APPSIGNAL_LOG_PATH"),
             name=os.environ.get("APPSIGNAL_APP_NAME"),
@@ -204,6 +208,7 @@ class Config:
             "_APPSIGNAL_IGNORE_NAMESPACES": list_to_env_str(
                 options.get("ignore_namespaces")
             ),
+            "_APPSIGNAL_LOG": options.get("log"),
             "_APPSIGNAL_LOG_LEVEL": options.get("log_level"),
             "_APPSIGNAL_LOG_FILE_PATH": self.log_file_path(),
             "_APPSIGNAL_PUSH_API_KEY": options.get("push_api_key"),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -85,6 +85,11 @@ def test_logger_debug_level():
     assert client._logger.getEffectiveLevel() == DEBUG
 
 
+def test_logger_trace_level():
+    client = Client(log_level="trace")
+    assert client._logger.getEffectiveLevel() == DEBUG
+
+
 def test_logger_file(tmp_path):
     log_path = tmp_path
     log_file_path = os.path.join(log_path, "appsignal.log")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,8 @@
 from appsignal.client import Client
 
 import os
+import re
+from logging import ERROR, WARNING, INFO, DEBUG
 
 
 def test_client_options_merge_sources():
@@ -58,3 +60,43 @@ def test_client_inactive():
         os.environ.get("OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST")
         is None
     )
+
+
+def test_logger_default_level():
+    client = Client()
+    assert client._logger.getEffectiveLevel() == INFO
+
+    client = Client(log_level="info")
+    assert client._logger.getEffectiveLevel() == INFO
+
+
+def test_logger_error_level():
+    client = Client(log_level="error")
+    assert client._logger.getEffectiveLevel() == ERROR
+
+
+def test_logger_warning_level():
+    client = Client(log_level="warning")
+    assert client._logger.getEffectiveLevel() == WARNING
+
+
+def test_logger_debug_level():
+    client = Client(log_level="debug")
+    assert client._logger.getEffectiveLevel() == DEBUG
+
+
+def test_logger_file(tmp_path):
+    log_path = tmp_path
+    log_file_path = os.path.join(log_path, "appsignal.log")
+
+    client = Client(log_path=log_path)
+    logger = client._logger
+    logger.info("test me")
+
+    with open(log_file_path) as file:
+        contents = file.read()
+
+    log_line_regex = re.compile(
+        r"\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2} \(process\) #\d+\]\[INFO\] test me"
+    )
+    assert log_line_regex.search(contents)


### PR DESCRIPTION
Allow us to log things to the appsignal.log file.
Add a new "appsignal" logger in Python and configure it to match our logging standard.
https://github.com/appsignal/integration-guide/blob/e0faa6a9e02265b375a449ec6b0f234ccc68834a/build/logging.md

Use the tmp_path helper argument in pytest to create a temporary path to store the log file in for testing.

There is no "trace" level in Python. Not sure how we can support that.

This doesn't implement the STDOUT logger. That's the next step.

[skip changeset]
Part of #34 