### PR TITLE
Add request_headers config option

### DIFF
--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -15,6 +15,6 @@ class Client:
         self._config = Config(options)
 
     def start(self):
-        if self._config.options.get("active"):
+        if self._config.option("active"):
             start_agent(self._config)
             start_opentelemetry(self._config)

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -37,6 +37,7 @@ class Options(TypedDict, total=False):
     name: Optional[str]
     push_api_key: Optional[str]
     revision: Optional[str]
+    request_headers: Optional[list[str]]
     running_in_container: Optional[bool]
     send_environment_metadata: Optional[bool]
     send_params: Optional[bool]
@@ -68,6 +69,16 @@ class Config:
         send_environment_metadata=True,
         send_params=True,
         send_session_data=True,
+        request_headers=[
+            "accept",
+            "accept-charset",
+            "accept-encoding",
+            "accept-language",
+            "cache-control",
+            "connection",
+            "content-length",
+            "range",
+        ],
     )
 
     DefaultInstrumentation = Literal[
@@ -138,6 +149,7 @@ class Config:
             name=os.environ.get("APPSIGNAL_APP_NAME"),
             push_api_key=os.environ.get("APPSIGNAL_PUSH_API_KEY"),
             revision=os.environ.get("APP_REVISION"),
+            request_headers=parse_list(os.environ.get("APPSIGNAL_REQUEST_HEADERS")),
             running_in_container=parse_bool(
                 os.environ.get("APPSIGNAL_RUNNING_IN_CONTAINER")
             ),

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
+import os
 
-from .config import Config
+from .config import Config, list_to_env_str
 
 from typing import Callable
 
@@ -69,6 +70,13 @@ DEFAULT_INSTRUMENTATION_ADDERS: DefaultInstrumentationAdders = {
 
 
 def start_opentelemetry(config: Config):
+    # Configure OpenTelemetry request headers config
+    request_headers = list_to_env_str(config.option("request_headers"))
+    if request_headers:
+        os.environ[
+            "OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST"
+        ] = request_headers
+
     provider = TracerProvider()
 
     otlp_exporter = OTLPSpanExporter(endpoint="http://localhost:8099")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,14 +12,37 @@ def test_client_options_merge_sources():
 
 
 def test_client_active():
-    client = Client(active=True, name="MyApp")
+    client = Client(
+        active=True, name="MyApp", request_headers=["accept", "x-custom-header"]
+    )
     assert client._config.options["active"] is True
     assert client._config.options["name"] == "MyApp"
+    assert client._config.options["request_headers"] == ["accept", "x-custom-header"]
     client.start()
 
     # Sets the private config environment variables
     assert os.environ.get("_APPSIGNAL_ACTIVE") == "true"
     assert os.environ.get("_APPSIGNAL_APP_NAME") == "MyApp"
+    assert (
+        os.environ.get("OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST")
+        == "accept,x-custom-header"
+    )
+
+
+def test_client_active_without_request_headers():
+    client = Client(active=True, name="MyApp", request_headers=None)
+    assert client._config.options["active"] is True
+    assert client._config.options["name"] == "MyApp"
+    assert client._config.options["request_headers"] is None
+    client.start()
+
+    # Sets the private config environment variables
+    assert os.environ.get("_APPSIGNAL_ACTIVE") == "true"
+    assert os.environ.get("_APPSIGNAL_APP_NAME") == "MyApp"
+    assert (
+        os.environ.get("OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST")
+        is None
+    )
 
 
 def test_client_inactive():
@@ -31,3 +54,7 @@ def test_client_inactive():
     # Does not set the private config environment variables
     assert os.environ.get("_APPSIGNAL_ACTIVE") is None
     assert os.environ.get("_APPSIGNAL_APP_NAME") is None
+    assert (
+        os.environ.get("OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST")
+        is None
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,6 +40,7 @@ def test_environ_source():
     os.environ["APPSIGNAL_LOG_PATH"] = "/path/to/log_dir"
     os.environ["APPSIGNAL_PUSH_API_KEY"] = "some-api-key"
     os.environ["APPSIGNAL_PUSH_API_ENDPOINT"] = "https://push.appsignal.com"
+    os.environ["APPSIGNAL_REQUEST_HEADERS"] = "accept,x-custom-header"
     os.environ["APPSIGNAL_RUNNING_IN_CONTAINER"] = "true"
     os.environ["APPSIGNAL_SEND_ENVIRONMENT_METADATA"] = "true"
     os.environ["APPSIGNAL_SEND_PARAMS"] = "true"
@@ -71,6 +72,7 @@ def test_environ_source():
         name="MyApp",
         push_api_key="some-api-key",
         revision="abc123",
+        request_headers=["accept", "x-custom-header"],
         running_in_container=True,
         send_environment_metadata=True,
         send_params=True,


### PR DESCRIPTION
Allow users to specify an allow list of request headers. Configure the OpenTelemetry instrumentation using the env var. There is no config option on the Django or wsgi/asgi instrumentations to specify it another way, only the env var.

There is a small difference between what you configure and what you see in the AppSignal.com UI. The header name for the `request_headers` config option needs to be using dashes (if the header uses dashes), but it will show up with underscores, because that's how OpenTelemetry exports it.

- Header name: `X-Custom-Header`
- Config: `x-custom-header` (case insensitive)
- Reported name: `x_custom_header`

I hope this won't be too confusing, let's document it properly. And we can always change it later, but this is easiest to implement now.

[skip changeset]
[skip review]
Part of #16
Reapply #39 after bad merge