### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "appsignal"
 description = 'The AppSignal integration for the Python programming language'
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 keywords = []
 authors = [
   { name = "Tom de Bruijn", email = "tom@tomdebruijn.com" },
@@ -15,7 +15,6 @@ authors = [
 classifiers = [
   # Python versions
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -60,7 +59,7 @@ cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=src --
 no-cov = "cov --no-cov {args}"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["37", "38", "39", "310", "311"]
+python = ["38", "39", "310", "311"]
 
 [tool.hatch.envs.lint]
 detached = true


### PR DESCRIPTION
It's going to be EOL on 2023-06-27, so let's drop support now and save ourselves the trouble.

[skip changeset]
Part of #48