### PR TITLE
Fix package for Python 3.8

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,6 +31,10 @@ blocks:
   dependencies: []
   task:
     jobs:
+    - name: Python 3.8
+      commands:
+      - "sem-version python 3.8"
+      - "hatch run test.py38:pytest"
     - name: Python 3.9
       commands:
       - "sem-version python 3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ Source = "https://github.com/appsignal/appsignal-python"
 [project.scripts]
 appsignal = "appsignal.cli:run"
 
+[tool.pytest.ini_options]
+pythonpath = [
+  "src"
+]
+
 [tool.hatch.version]
 path = "src/appsignal/__about__.py"
 

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -100,12 +100,12 @@ class Config:
             initial=options or Options(),
             environment=Config.load_from_environment(),
         )
-        self.options = (
-            self.sources["default"]
-            | self.sources["system"]
-            | self.sources["initial"]
-            | self.sources["environment"]
-        )
+        final_options = Options()
+        final_options.update(self.sources["default"])
+        final_options.update(self.sources["system"])
+        final_options.update(self.sources["initial"])
+        final_options.update(self.sources["environment"])
+        self.options = final_options
 
     def option(self, option: str):
         return self.options.get(option)
@@ -220,7 +220,8 @@ class Config:
             ),
             "_APPSIGNAL_WORKING_DIRECTORY_PATH": options.get("working_directory_path"),
             "_APP_REVISION": options.get("revision"),
-        } | self.CONSTANT_PRIVATE_ENVIRON
+        }
+        private_environ.update(self.CONSTANT_PRIVATE_ENVIRON)
 
         for var, value in private_environ.items():
             if value is not None:

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from .__about__ import __version__
+from typing import List
 
 import os
 import platform
@@ -89,7 +90,7 @@ class Config:
         "opentelemetry.instrumentation.requests",
     ]
     DEFAULT_INSTRUMENTATIONS = cast(
-        list[DefaultInstrumentation], list(get_args(DefaultInstrumentation))
+        List[DefaultInstrumentation], list(get_args(DefaultInstrumentation))
     )
 
     def __init__(self, options: Optional[Options] = None):
@@ -284,7 +285,7 @@ def parse_disable_default_instrumentations(
         return False
 
     return cast(
-        list[Config.DefaultInstrumentation],
+        List[Config.DefaultInstrumentation],
         [x for x in value.split(",") if x in Config.DEFAULT_INSTRUMENTATIONS],
     )
 

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import os
+from typing import Dict
 
 from .config import Config, list_to_env_str
 
@@ -55,7 +56,7 @@ def add_requests_instrumentation():
 
 
 DefaultInstrumentationAdder = Callable[[], None]
-DefaultInstrumentationAdders = dict[
+DefaultInstrumentationAdders = Dict[
     Config.DefaultInstrumentation, DefaultInstrumentationAdder
 ]
 

--- a/src/scripts/build_hook.py
+++ b/src/scripts/build_hook.py
@@ -1,5 +1,6 @@
 from typing import Any
 from runpy import run_path
+from typing import Dict
 import os
 import stat
 import hashlib
@@ -77,7 +78,7 @@ class DownloadError(Exception):
 
 
 class CustomBuildHook(BuildHookInterface):
-    def initialize(self, _version: str, build_data: dict[str, Any]) -> None:
+    def initialize(self, _version: str, build_data: Dict[str, Any]) -> None:
         """
         This occurs immediately before each build.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,9 +80,11 @@ def test_environ_source():
         working_directory_path="/path/to/working/dir",
     )
     assert config.sources["environment"] == env_options
-    assert config.options == (
-        config.sources["default"] | config.sources["system"] | env_options
-    )
+    final_options = Options()
+    final_options.update(config.sources["default"])
+    final_options.update(config.sources["system"])
+    final_options.update(env_options)
+    assert config.options == final_options
 
 
 def test_environ_source_bool_is_unset():

--- a/tests/test_opentelemetry.py
+++ b/tests/test_opentelemetry.py
@@ -1,4 +1,5 @@
 from unittest.mock import Mock
+from typing import Dict
 
 from appsignal.config import Config, Options
 from appsignal.opentelemetry import add_instrumentations
@@ -8,7 +9,7 @@ def raise_module_not_found_error():
     raise ModuleNotFoundError()
 
 
-def mock_adders() -> dict[Config.DefaultInstrumentation, Mock]:
+def mock_adders() -> Dict[Config.DefaultInstrumentation, Mock]:
     return {
         "opentelemetry.instrumentation.celery": Mock(),
         "opentelemetry.instrumentation.jinja2": Mock(


### PR DESCRIPTION
## Configure Python path for Python 3.8

When trying to set up Python 3.8 for the CI and local test suite, it wouldn't load the package files when importing them.

There's a difference in Python 3.8 and 3.9 about the `src` directory for packages. Configure the pythonpath for Python 3.8 so it loads the files properly.

https://stackoverflow.com/a/50156706/543643

[skip changeset] Part of #48

## Fix Python 3.8 type issues

Specify the types using the typing module's variants, rather than the normal list and dict types.

Fixes this error:

```
tests/test_config.py:4: in <module>
    from appsignal.config import Config, Options
src/appsignal/__init__.py:1: in <module>
    from .client import Client as Appsignal
src/appsignal/client.py:3: in <module>
    from .agent import start_agent
src/appsignal/agent.py:6: in <module>
    from .config import Config
src/appsignal/config.py:55: in <module>
    class Config:
src/appsignal/config.py:93: in Config
    list[DefaultInstrumentation], list(get_args(DefaultInstrumentation))
E   TypeError: 'type' object is not subscriptable
```

[skip changeset] Part of #48

## Fix TypedDict unions for Python 3.8

Python 3.8 doesn't support unions for TypedDicts. That's been added in PEP 584 [1] for Python 3.9.

Use the older approach of updating the dict using the `update` method.

[1]: https://peps.python.org/pep-0584/

[skip changeset] Part of #48

## Add Python 3.8 to CI

The CI was missing a job for the Python 3.8 testing.

[skip changeset] Closes #48

## Fix typing error in build_hook.py script

We need to use the typing module for these types in Python 3.8.

[skip changeset] Part of #48
