### PR TITLE
Listen and register agent exit code

### DIFF
--- a/src/appsignal/agent.py
+++ b/src/appsignal/agent.py
@@ -6,9 +6,31 @@ import subprocess
 from .config import Config
 
 AGENT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "appsignal-agent")
+agent_active = False
+
+
+def is_agent_active():
+    global agent_active
+    return agent_active
+
+
+def agent_is_active():
+    global agent_active
+    agent_active = True
 
 
 def start_agent(config: Config):
     config.set_private_environ()
-
-    subprocess.Popen([AGENT_PATH, "start", "--private"])
+    p = subprocess.Popen(
+        [AGENT_PATH, "start", "--private"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    p.wait(timeout=1)
+    returncode = p.returncode
+    if returncode == 0:
+        agent_is_active()
+    else:
+        output, _ = p.communicate()
+        out = output.decode("utf-8")
+        print(f"AppSignal agent is unable to start ({returncode}): ", out)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,5 @@
 from appsignal.client import Client
+from appsignal.agent import is_agent_active
 
 import os
 import re
@@ -13,9 +14,29 @@ def test_client_options_merge_sources():
     assert "app_path" in client._config.options
 
 
+def test_client_agent_inactive():
+    client = Client(active=True, name="MyApp")
+    assert client._config.options["active"] is True
+    client.start()
+
+    assert os.environ.get("_APPSIGNAL_ACTIVE") == "true"
+    assert is_agent_active() is False
+
+
+def test_client_agent_active():
+    client = Client(active=True, name="MyApp", push_api_key="000")
+    assert client._config.options["active"] is True
+    client.start()
+
+    assert os.environ.get("_APPSIGNAL_ACTIVE") == "true"
+    assert is_agent_active() is True
+
+
 def test_client_active():
     client = Client(
-        active=True, name="MyApp", request_headers=["accept", "x-custom-header"]
+        active=True,
+        name="MyApp",
+        request_headers=["accept", "x-custom-header"],
     )
     assert client._config.options["active"] is True
     assert client._config.options["name"] == "MyApp"
@@ -29,6 +50,7 @@ def test_client_active():
         os.environ.get("OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST")
         == "accept,x-custom-header"
     )
+    assert is_agent_active()
 
 
 def test_client_active_without_request_headers():


### PR DESCRIPTION
When the agent is started, track if it's started correctly. This will help debug issues and warn people when the agent can't start for whatever reason.

I've added a global `agent_active` variable which can be accessed through the `is_agent_active` helper function. It doesn't update if you import the global variable directly. Useful for the diagnose tool later on.

Listen for the exit code from the agent after starting the agent. The Python app will wait until the agent has started and exited.

This would normally cause a TimeoutError, because the agent will need to continue to run and `wait` waits for it to exit. However, turns out we still daemonize the agent in this scenario (it's not marked as standalone mode). So when it daemonizes we can assume it has started properly. If the config is invalid according to the agent, it will exit with an error before daemonizing.

This may add a small delay to the boot of the program, as long as the agent needs to start and daemonize. We can possibly do this async in the future, but I couldn't figure it out.

[skip changeset]