### PR TITLE
Fix log path failure log message

### DIFF
--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -241,11 +241,11 @@ class Config:
                 path = os.path.dirname(path)
 
             if not os.access(path, os.W_OK):
-                path = None
                 print(
                     f"appsignal: Unable to write to configured '{path}'. Please "
                     "check the permissions of the 'log_path' directory."
                 )
+                path = None
 
         if not path:
             path = "/tmp" if platform.system() == "Darwin" else tempfile.gettempdir()


### PR DESCRIPTION
This currently prints "Unable to write to configured 'None'", which is not what we want.

Quick thing I noticed while looking into the log output issue in #56.