### PR TITLE
Add demo command

### DIFF
--- a/src/appsignal/cli.py
+++ b/src/appsignal/cli.py
@@ -1,22 +1,28 @@
 from abc import ABC, abstractmethod
 import os
+import json
 
 from typing import Optional
 from docopt import docopt
 
 from .__about__ import __version__
 
+from appsignal.client import Client
+from opentelemetry import trace
+
 DOC = """AppSignal for Python CLI.
 
 Usage:
   appsignal install [--push-api-key=<key>]
+  appsignal demo [--application=<app>] [--push-api-key=<key>]
   appsignal (-h | --help)
   appsignal --version
 
 Options:
   -h --help             Show this screen and exit.
   --version             Show version number and exit.
-  --push-api-key=<key>  Push API Key to use for the installation.
+  --push-api-key=<key>  Push API Key to use for the installation and the demo.
+  --application=<app>   Application name to use for the demo.
 """
 
 
@@ -40,6 +46,11 @@ class CLICommand(ABC):
 def command_for(arguments) -> CLICommand:
     if arguments["install"]:
         return InstallCommand(push_api_key=arguments["--push-api-key"])
+    if arguments["demo"]:
+        return DemoCommand(
+            push_api_key=arguments["--push-api-key"],
+            application=arguments["--application"],
+        )
     else:
         raise NotImplementedError
 
@@ -56,10 +67,23 @@ appsignal = Appsignal(
 INSTALL_FILE_NAME = "__appsignal__.py"
 
 
-class InstallCommand(CLICommand):
+class AppsignalCLICommand(CLICommand):
     _push_api_key: Optional[str]
     _name: Optional[str]
 
+    def _input_push_api_key(self):
+        key = input("Please enter your Push API key: ")
+        self._push_api_key = key
+        if self._push_api_key == "":
+            self._input_push_api_key()
+
+    def _input_name(self):
+        self._name = input("Please enter the name of your application: ")
+        if self._name == "":
+            self._input_name()
+
+
+class InstallCommand(AppsignalCLICommand):
     def __init__(self, push_api_key=None):
         self._push_api_key = push_api_key
         self._name = None
@@ -82,6 +106,9 @@ class InstallCommand(CLICommand):
             print(f"Writing the {INSTALL_FILE_NAME} configuration file...")
             self._write_file()
             print()
+
+            DemoCommand(push_api_key=self._push_api_key, application=self._name).run()
+
             print("✅ Done! AppSignal for Python has now been installed.")
             print()
             print(
@@ -116,17 +143,6 @@ class InstallCommand(CLICommand):
             print('Please answer "y" (yes) or "n" (no)')
             return self._input_should_overwrite_file()
 
-    def _input_push_api_key(self):
-        key = input("Please enter your Push API key: ")
-        self._push_api_key = key
-        if self._push_api_key == "":
-            self._input_push_api_key()
-
-    def _input_name(self):
-        self._name = input("Please enter the name of your application: ")
-        if self._name == "":
-            self._input_name()
-
     def _write_file(self):
         with open(INSTALL_FILE_NAME, "w") as f:
             file_contents = INSTALL_FILE_TEMPLATE.format(
@@ -135,3 +151,65 @@ class InstallCommand(CLICommand):
             )
 
             f.write(file_contents)
+
+
+class DemoCommand(AppsignalCLICommand):
+    def __init__(self, push_api_key=None, application=None):
+        self._push_api_key = push_api_key or os.environ.get("APPSIGNAL_PUSH_API_KEY")
+        self._name = application or os.environ.get("APPSIGNAL_APP_NAME")
+
+    def run(self) -> int:
+        if self._push_api_key is None:
+            self._input_push_api_key()
+
+        if self._name is None:
+            self._input_name()
+
+        print()
+
+        client = Client(
+            active=True,
+            name=self._name,
+            push_api_key=self._push_api_key,
+            log_level="trace",
+        )
+
+        print("Sending example data to AppSignal...")
+        print(f"Starting AppSignal client for {self._name}...")
+        client.start()
+
+        tracer = trace.get_tracer(__name__)
+
+        # Performance sample
+        with tracer.start_as_current_span("GET /demo") as span:
+            span.set_attribute("http.method", "GET")
+            span.set_attribute(
+                "appsignal.request.parameters",
+                json.dumps({"GET": {"id": 1}, "POST": {}}),
+            )
+            span.set_attribute(
+                "otel.instrumentation_library.name",
+                "opentelemetry.instrumentation.wsgi",
+            )
+            span.set_attribute(
+                "demo_sample",
+                True,
+            )
+
+        # Error sample
+        with tracer.start_as_current_span("GET /demo") as span:
+            span.set_attribute("http.method", "GET")
+            span.set_attribute(
+                "appsignal.request.parameters",
+                json.dumps({"GET": {"id": 1}, "POST": {}}),
+            )
+            span.set_attribute(
+                "demo_sample",
+                True,
+            )
+            try:
+                raise ValueError("Something went wrong")
+            except ValueError as e:
+                span.record_exception(e)
+
+        return 0


### PR DESCRIPTION
Demo CLI command that sends two sample actions to AppSignal. One standard HTTP one and an error.

The install command now calls the demo command when finishing.

Part of: https://github.com/appsignal/appsignal-python/issues/12

[skip changeset]