### PR TITLE
Add Flask integration

### DIFF
--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -87,6 +87,7 @@ class Config:
     DefaultInstrumentation = Literal[
         "opentelemetry.instrumentation.celery",
         "opentelemetry.instrumentation.django",
+        "opentelemetry.instrumentation.flask",
         "opentelemetry.instrumentation.jinja2",
         "opentelemetry.instrumentation.psycopg2",
         "opentelemetry.instrumentation.redis",

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -31,6 +31,12 @@ def add_django_instrumentation():
     DjangoInstrumentor().instrument(response_hook=response_hook)
 
 
+def add_flask_instrumentation():
+    from opentelemetry.instrumentation.flask import FlaskInstrumentor
+
+    FlaskInstrumentor().instrument()
+
+
 def add_jinja2_instrumentation():
     from opentelemetry.instrumentation.jinja2 import Jinja2Instrumentor
 
@@ -63,6 +69,7 @@ DefaultInstrumentationAdders = Dict[
 DEFAULT_INSTRUMENTATION_ADDERS: DefaultInstrumentationAdders = {
     "opentelemetry.instrumentation.celery": add_celery_instrumentation,
     "opentelemetry.instrumentation.django": add_django_instrumentation,
+    "opentelemetry.instrumentation.flask": add_flask_instrumentation,
     "opentelemetry.instrumentation.jinja2": add_jinja2_instrumentation,
     "opentelemetry.instrumentation.psycopg2": add_psycopg2_instrumentation,
     "opentelemetry.instrumentation.redis": add_redis_instrumentation,


### PR DESCRIPTION
Automatically start the Flask instrumentor included in the SDK when starting the AppSignal client.

Part of: https://github.com/appsignal/appsignal-python/issues/9

[skip changeset]