### PR TITLE
Fix test suite state

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import pytest
+from appsignal.agent import _reset_agent_active
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -20,3 +21,8 @@ def remove_logging_handlers_after_tests():
     logger = logging.getLogger("appsignal")
     for handler in logger.handlers:
         logger.removeHandler(handler)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def reset_agent_active_state():
+    _reset_agent_active()

--- a/src/appsignal/agent.py
+++ b/src/appsignal/agent.py
@@ -14,6 +14,11 @@ def is_agent_active():
     return agent_active
 
 
+def _reset_agent_active():
+    global agent_active
+    agent_active = False
+
+
 def agent_is_active():
     global agent_active
     agent_active = True

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -37,15 +37,18 @@ def test_client_active():
         active=True,
         name="MyApp",
         request_headers=["accept", "x-custom-header"],
+        push_api_key="0000-0000-0000-0000",
     )
     assert client._config.options["active"] is True
     assert client._config.options["name"] == "MyApp"
     assert client._config.options["request_headers"] == ["accept", "x-custom-header"]
+    assert client._config.options["push_api_key"] == "0000-0000-0000-0000"
     client.start()
 
     # Sets the private config environment variables
     assert os.environ.get("_APPSIGNAL_ACTIVE") == "true"
     assert os.environ.get("_APPSIGNAL_APP_NAME") == "MyApp"
+    assert os.environ.get("_APPSIGNAL_PUSH_API_KEY") == "0000-0000-0000-0000"
     assert (
         os.environ.get("OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST")
         == "accept,x-custom-header"


### PR DESCRIPTION
## Reset agent_active() between tests

The agent_active variable is a global state that doesn't reflect the actual environment of some tests. Reset it between tests so that tests that shouldn't have an active agent, do not.

## Fix "active" state in test

Make the config actually something the agent can start with. Without the Push API key it doesn't start the agent and fails the test. Not sure how this only failed after merging #56.

[skip changeset]