### PR TITLE
Make sure agent is stopped before every test

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,9 @@
 import os
 import logging
 import pytest
+import platform
+import shutil
+import tempfile
 from appsignal.agent import _reset_agent_active
 
 
@@ -26,3 +29,13 @@ def remove_logging_handlers_after_tests():
 @pytest.fixture(scope="function", autouse=True)
 def reset_agent_active_state():
     _reset_agent_active()
+
+
+@pytest.fixture(scope="function", autouse=True)
+def stop_agent():
+    tmp_path = "/tmp" if platform.system() == "Darwin" else tempfile.gettempdir()
+    working_dir = os.path.join(tmp_path, "appsignal")
+    if os.path.isdir(working_dir):
+        shutil.rmtree(working_dir)
+
+    yield


### PR DESCRIPTION
A bunch of tests start, or try to start, the agent with different configs. These can conflict with each other and not start the agent when it is supposed to. A common error I see in the appsignal.log is this:

```
[2023-05-24T11:25:59 (agent) #43777][Debug] Booting appsignal-agent
[2023-05-24T11:25:59 (agent) #43778][Debug] Starting appsignal-agent in daemonized mode
[2023-05-24T11:25:59 (agent) #43778][Debug] Exiting agent, we did not become owner of the lock
[2023-05-24T11:25:59 (agent) #43778][Debug] is_currently_owner: Our pid is Some(43778), pid on disk is Some(43423)
```

Remove the AppSignal working directory before every test. This quickly shuts down the agent and fixes the OpenTelemetry connection error for port 8099 (the agent).

I also tried to make it work with psutil like so, but it still printed the error sometimes.

```python
# conftest.py
import psutil

AGENT_PROCESS_NAME = "appsignal-agent"

@pytest.fixture(scope="function", autouse=True)
def stop_agent():
    for proc in psutil.process_iter():
        if proc.name() == AGENT_PROCESS_NAME:
            proc.terminate()

    yield
```

[skip changeset]