### PR TITLE
Load file/initial config options source load

### DIFF
--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -107,8 +107,8 @@ class Config:
         final_options = Options()
         final_options.update(self.sources["default"])
         final_options.update(self.sources["system"])
-        final_options.update(self.sources["initial"])
         final_options.update(self.sources["environment"])
+        final_options.update(self.sources["initial"])
         self.options = final_options
 
     def option(self, option: str):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,27 @@ def test_option():
     assert config.option("nonsense") is None
 
 
+def test_source_order():
+    # Read only from default
+    config = Config()
+    assert config.sources["default"]["enable_host_metrics"] is True
+    assert config.option("enable_host_metrics") is True
+
+    # Read from environment
+    os.environ["APPSIGNAL_ENABLE_HOST_METRICS"] = "false"
+    config = Config()
+    assert config.sources["default"]["enable_host_metrics"] is True
+    assert config.sources["environment"]["enable_host_metrics"] is False
+    assert config.option("enable_host_metrics") is False
+
+    # Read from config initializer last
+    os.environ["APPSIGNAL_HOSTNAME"] = "env name"
+    config = Config(Options(hostname="initial name"))
+    assert config.sources["environment"]["hostname"] == "env name"
+    assert config.sources["initial"]["hostname"] == "initial name"
+    assert config.option("hostname") == "initial name"
+
+
 def test_system_source():
     config = Config()
 


### PR DESCRIPTION
As discussed in the integrations guide issue https://github.com/appsignal/integration-guide/issues/73 Change the config source load order to use the "initial" config source last.

The environment source can be referenced from the config file and conditional behavior can be set based on it, but the given config to the initializer will be the final used config once merged with the other sources.

New load order:

- Default source (hardcoded config)
- System source (context dependent config)
- Environment source (environment variables)
- Initial source (any config given to `Config()` in `__appsignal__.py`)

[skip changeset]