### PR TITLE
Fix hatch build script

### DIFF
--- a/src/scripts/sdist_hook.py
+++ b/src/scripts/sdist_hook.py
@@ -1,9 +1,9 @@
-from typing import Any
+from typing import Any, Dict
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
 
 class CustomBuildHook(BuildHookInterface):
-    def initialize(self, version: str, build_data: dict[str, Any]) -> None:
+    def initialize(self, version: str, build_data: Dict[str, Any]) -> None:
         """
         This occurs immediately before each build.
 


### PR DESCRIPTION
This script should fail, but it failed on a vague error, rather than the intended error on Python 3.11.

```
  File "/Users/tombruijn/appsignal/python/src/scripts/sdist_hook.py", line 6, in CustomBuildHook
    def initialize(self, version: str, build_data: dict[str, Any]) -> None:
TypeError: 'type' object is not subscriptable
```

[skip changeset]