### PR TITLE
Fix certificate error in installer

### DIFF
--- a/.changesets/fix-certificate-error-in-installer.md
+++ b/.changesets/fix-certificate-error-in-installer.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix an issue where the installer would fail due to the certificate bundle being missing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,12 @@ path = "src/appsignal/__about__.py"
 
 [tool.hatch.build]
 sources = ["src"]
-exclude = ["src/scripts"]
-artifacts = ["src/appsignal/appsignal-agent"]
+exclude = ["src/scripts", "tests", "conftest.py"]
+artifacts = [
+  "src/appsignal/appsignal-agent",
+  "src/appsignal/resources/cacert.pem",
+  "src/appsignal/py.typed",
+]
 
 [tool.hatch.envs.default]
 dependencies = [


### PR DESCRIPTION
Make sure that the `cacert.pem` file is added to the package.

While we're at it, remove the unit tests from the package, and make sure `py.typed` is added as well.