### PR TITLE
Allow custom agent builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ hatch run build:me # for your current platform
 hatch run build:for <triple> # for a specific agent triple
 ```
 
+#### Custom agent build
+```sh
+hatch run build:me /path/to/agent
+# or place the desired agent binary at
+# `src/appsignal/appsignal-agent`, and then:
+hatch run build:me --keep-agent
+```
+
 ### Clean up build artifacts
 ```sh
 hatch clean # clean dist folder

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## Installation
 
 ```console
-pip install appsignal
+pip install appsignal-beta
 ```
 
 ## Development

--- a/mono.yml
+++ b/mono.yml
@@ -4,7 +4,7 @@ repo: "https://github.com/appsignal/appsignal-python"
 bootstrap:
   command: ""
 clean:
-  command: "hatch clean; rm src/appsignal/appsignal-agent"
+  command: "hatch clean; rm -r tmp; rm src/appsignal/appsignal-agent"
 build:
   command: "mono clean; hatch run build:all"
 publish:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,8 +104,8 @@ extend-exclude = ["src/scripts/agent.py"]
 
 [tool.hatch.envs.build.scripts]
 all = "python src/scripts/build_all.py"
-me = "hatch build -t wheel"
-for = "_APPSIGNAL_BUILD_TRIPLE={args} hatch build -t wheel"
+me = "_APPSIGNAL_BUILD_AGENT_PATH=\"{args}\" hatch build -t wheel"
+for = "_APPSIGNAL_BUILD_TRIPLE=\"{args}\" hatch build -t wheel"
 
 [tool.hatch.build.targets.wheel.hooks.custom]
 path = "src/scripts/build_hook.py"

--- a/src/scripts/build_hook.py
+++ b/src/scripts/build_hook.py
@@ -144,6 +144,9 @@ class CustomBuildHook(BuildHookInterface):
                     tar_agent = tar.extractfile("appsignal-agent")
                     if tar_agent is not None:
                         agent.write(tar_agent.read())
+                    else:
+                        print("Failed to extract agent binary; exiting...")
+                        exit(1)
 
             with open(tempversion_path, "w") as version:
                 version.write(APPSIGNAL_AGENT_CONFIG["version"])

--- a/src/scripts/build_hook.py
+++ b/src/scripts/build_hook.py
@@ -101,6 +101,13 @@ class CustomBuildHook(BuildHookInterface):
         build_data["pure_python"] = False
 
         agent_path = os.path.join(self.root, "src", "appsignal", "appsignal-agent")
+
+        if os.environ.get(
+            "_APPSIGNAL_BUILD_AGENT_PATH", ""
+        ).strip() == "--keep-agent" and os.path.isfile(agent_path):
+            print(f"Using existing agent binary at {agent_path}")
+            return
+
         rm(agent_path)
 
         tempdir_path = os.path.join(self.root, "tmp", triple)
@@ -109,7 +116,19 @@ class CustomBuildHook(BuildHookInterface):
         tempagent_path = os.path.join(tempdir_path, "appsignal_agent")
         tempversion_path = os.path.join(tempdir_path, "version")
 
-        if should_download(tempagent_path, tempversion_path):
+        if os.environ.get("_APPSIGNAL_BUILD_AGENT_PATH", "").strip() != "":
+            tempagent_path = os.path.abspath(
+                os.environ["_APPSIGNAL_BUILD_AGENT_PATH"].strip()
+            )
+
+            if not os.path.isfile(tempagent_path):
+                print(
+                    f"Custom agent binary at {tempagent_path} is not a file; exiting..."
+                )
+                exit(1)
+
+            print(f"Using custom agent binary at {tempagent_path}")
+        elif should_download(tempagent_path, tempversion_path):
             temptar_path = os.path.join(tempdir_path, triple_filename(triple))
 
             rm(tempagent_path)


### PR DESCRIPTION
[skip changeset] because this is all build script related

### [Remove the agent cache on clean](https://github.com/appsignal/appsignal-python/commit/dc6f0809ce7bec61a79529e858d1c74e3aa74af9)

When `mono clean` is invoked, the agent binaries should be
downloaded again, in case the agent binary cache was tampered with.

### [Exit if tarball has no agent binary](https://github.com/appsignal/appsignal-python/commit/1b5ae8b2543eae1b1af70e524b712076f402229a)

Not sure how this would happen, but we should error if it does.

### [Allow custom agent builds](https://github.com/appsignal/appsignal-python/commit/d5557b94f545b0ced2e1539f8d900fd3371ba762)

An argument can be passed to `hatch run build:me` specifying the
path to the agent: `hatch run build:me path/to/agent`.

Additionally, you can use the `--keep-agent` flag to use the current
agent binary that is already present at `src/appsignal/appsignal-agent`
from a previous build: `hatch run build:me --keep-agent`.

The latter can be useful in containerised environments like our test
setups, which mount the integration repository as a volume in a
container, but not the agent repository -- meaning the location of the
agent artifact is not accessible when the integration package is
being built.