### PR TITLE
Bump agent to 91f1a7c

### DIFF
--- a/.changesets/bump-agent-to-91f1a7c.md
+++ b/.changesets/bump-agent-to-91f1a7c.md
@@ -1,0 +1,10 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to 91f1a7c
+
+- Fall back on the revision option for OpenTelemetry endpoint from config, rather than only read it from the OpenTelemetry resource attributes.
+- Fix agent restart when the config changes, not detecting a config change and not starting a new agent process.
+- Retry agent servers port binding when port is busy. This fixes Python package restarting the agent when another agent instance is still running.

--- a/src/scripts/agent.py
+++ b/src/scripts/agent.py
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-    "version": "d21e1f4",
+    "version": "91f1a7c",
     "mirrors": [
         "https://appsignal-agent-releases.global.ssl.fastly.net",
         "https://d135dj0rjqvssy.cloudfront.net",
@@ -12,131 +12,131 @@ APPSIGNAL_AGENT_CONFIG = {
     "triples": {
         "x86_64-darwin": {
             "static": {
-                "checksum": "a3e5ce6951b6c123515df52d1862e39685ea8d4667b80efc0b176162f1bf230f",
+                "checksum": "c05dc1dd39862a709022681a6458de9137bb7bdf53f46ab0507029343cc09fef",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "10aa05e070dfbaab7632bb6904f746cdd06d1aa2e03e879795580e051e01f895",
+                "checksum": "e15fc014c3d0fc55ada0c1aede241349a7dfc33e2d78523a576c76f95ead1cd1",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "universal-darwin": {
             "static": {
-                "checksum": "a3e5ce6951b6c123515df52d1862e39685ea8d4667b80efc0b176162f1bf230f",
+                "checksum": "c05dc1dd39862a709022681a6458de9137bb7bdf53f46ab0507029343cc09fef",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "10aa05e070dfbaab7632bb6904f746cdd06d1aa2e03e879795580e051e01f895",
+                "checksum": "e15fc014c3d0fc55ada0c1aede241349a7dfc33e2d78523a576c76f95ead1cd1",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-darwin": {
             "static": {
-                "checksum": "b20059bf8bc3ef7bc5c909d2eb24624e49c207e7b49ecadd43ac793991854077",
+                "checksum": "973305782e3e123436cc784325d59d00622d14bc066eb0935ce34fac2f998977",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "0327c46572d60d03ee0053bcfe08b72fc42f10d78bd2e5c6fb74baed967da492",
+                "checksum": "cdeb358f6217d37a82204ef8e6a8503900f363b12b51263d6af1ebb233ba75d5",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm64-darwin": {
             "static": {
-                "checksum": "b20059bf8bc3ef7bc5c909d2eb24624e49c207e7b49ecadd43ac793991854077",
+                "checksum": "973305782e3e123436cc784325d59d00622d14bc066eb0935ce34fac2f998977",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "0327c46572d60d03ee0053bcfe08b72fc42f10d78bd2e5c6fb74baed967da492",
+                "checksum": "cdeb358f6217d37a82204ef8e6a8503900f363b12b51263d6af1ebb233ba75d5",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm-darwin": {
             "static": {
-                "checksum": "b20059bf8bc3ef7bc5c909d2eb24624e49c207e7b49ecadd43ac793991854077",
+                "checksum": "973305782e3e123436cc784325d59d00622d14bc066eb0935ce34fac2f998977",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "0327c46572d60d03ee0053bcfe08b72fc42f10d78bd2e5c6fb74baed967da492",
+                "checksum": "cdeb358f6217d37a82204ef8e6a8503900f363b12b51263d6af1ebb233ba75d5",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux": {
             "static": {
-                "checksum": "e03229f30714668a961bdfc87fa0d6aa16ebb6940fa285a7b564414b12b64745",
+                "checksum": "50a6f27614dea8867618c8677ebc2c67e3c095b3e7ca8580e60a0a75b12725c3",
                 "filename": "appsignal-aarch64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "d96f100c7b4b3546390cbd43cb46a0f2b8fc65783505c1db41565a62c8580940",
+                "checksum": "3eec7a8d7e13c4b549e56377c73697ee1082777f01e8e32d6111b28957912fde",
                 "filename": "appsignal-aarch64-linux-all-dynamic.tar.gz",
             },
         },
         "i686-linux": {
             "static": {
-                "checksum": "ba571ec9c44ddb435270fbe91a0b1cae480bf90f1117b430d925c86726c67d86",
+                "checksum": "1d1b3fdbfcb7f3388b16184f51c50d5eda17886b87214b1b81a281d876adb119",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "4b9f915d8c64371a673dbd86b5ac38e8b481c32d4f3220e02814b7c705a358b4",
+                "checksum": "fd7d3c0348023283c6a97f7b38cc7ae61c11f9d9f0336864b6436901096da438",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86-linux": {
             "static": {
-                "checksum": "ba571ec9c44ddb435270fbe91a0b1cae480bf90f1117b430d925c86726c67d86",
+                "checksum": "1d1b3fdbfcb7f3388b16184f51c50d5eda17886b87214b1b81a281d876adb119",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "4b9f915d8c64371a673dbd86b5ac38e8b481c32d4f3220e02814b7c705a358b4",
+                "checksum": "fd7d3c0348023283c6a97f7b38cc7ae61c11f9d9f0336864b6436901096da438",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux": {
             "static": {
-                "checksum": "084e5de892e0abde9034c816a9d287177bfcb1ca0b7b9c3a646a54acbda43d83",
+                "checksum": "9bb4ddfca296c1fab82e12ca9a88bbe3ec29f6c2628a891eabcbf1506a20145b",
                 "filename": "appsignal-x86_64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "b43fce9fdc4241f6ed3664af1b933b1960c6d2c4eb48f9a8027f64599d053da0",
+                "checksum": "b22564cd5f4569c27eddef01627ecccf343b6c5584e788bdd7efa22d7314e972",
                 "filename": "appsignal-x86_64-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux-musl": {
             "static": {
-                "checksum": "ee50cbe5e92c372981d53ca7daa902957fa86c44506a1d1486aa43b6d9dd7551",
+                "checksum": "4222ae184a822bebff8453e221666e53c581c0bbc0fb9f2150aa6dc000b0d564",
                 "filename": "appsignal-x86_64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "f90a9aef5c2d9b06b680af99204ad7cb6bf926ca8d985c5c46523ae3f49f63db",
+                "checksum": "b1b771cba1a49e148d4180921c174584e2c8a8d8fc8b38ac10dc35523f152f3b",
                 "filename": "appsignal-x86_64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux-musl": {
             "static": {
-                "checksum": "816a794fdcf84a830b8885cca188ac4c1d10287e7c6e1f76756870b63f5386b8",
+                "checksum": "531f036405796bdf4b1aefe91680f5009fa0f3a69c306937895248f6d50f74c5",
                 "filename": "appsignal-aarch64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "a4725482b6df4b4f3454bcc2a53b860724b36f7633778b79d3b6b7e4bae77471",
+                "checksum": "d9af4e7734451a7b3cf00016016ddbf2d6a59407db028d6a998d17e654e7524c",
                 "filename": "appsignal-aarch64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "x86_64-freebsd": {
             "static": {
-                "checksum": "d0e08b40007a6de2486902387931b15b53f82e5cf0fb160f72cf46ed046fcc01",
+                "checksum": "cc3c873d8dacfea995660b0fd931eacd9d479b3bc2f78d8a70cf9ac384e7f7d6",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "66a00ae3f2626743b88c25c98d0d310f07e42fa2713162d08acf754ce31377a3",
+                "checksum": "da332e442c7e1a306b8227dc09ad4ef25d523c8aea50cdf01048ab3e8e56cf9c",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },
         "amd64-freebsd": {
             "static": {
-                "checksum": "d0e08b40007a6de2486902387931b15b53f82e5cf0fb160f72cf46ed046fcc01",
+                "checksum": "cc3c873d8dacfea995660b0fd931eacd9d479b3bc2f78d8a70cf9ac384e7f7d6",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "66a00ae3f2626743b88c25c98d0d310f07e42fa2713162d08acf754ce31377a3",
+                "checksum": "da332e442c7e1a306b8227dc09ad4ef25d523c8aea50cdf01048ab3e8e56cf9c",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },


### PR DESCRIPTION
- Fall back on the revision option for OpenTelemetry endpoint from config, rather than only read it from the OpenTelemetry resource attributes.
- Fix agent restart when the config changes, not detecting a config change and not starting a new agent process.
- Retry agent servers port binding when port is busy. This fixes Python package restarting the agent when another agent instance is still running.

[skip review]