### PR TITLE
Add and update project files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Please visit [docs.appsignal.com/appsignal/code-of-conduct.html](https://docs.appsignal.com/appsignal/code-of-conduct.html) for our Code of Conduct for this project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing guide
+
+Want to contribute to this project? That's great! Here are a few guidelines
+that will help you contribute.
+
+Before we get started: Please note that this project is released with a [Code
+of Conduct](CODE_OF_CONDUCT.md) to ensure that this project is a welcoming
+place for **everyone** to contribute to. By participating in this project you
+agree to abide by its terms.
+
+See also the [AppSignal contributing
+guidelines](https://docs.appsignal.com/appsignal/contributing.html) for all
+projects.
+
+## Overview
+
+- [Contribution workflow](#contribution-workflow)
+- [Contributing to an existing issue](#contributing-to-an-existing-issue)
+
+## Contribution workflow
+
+- Create a branch based on the `main` branch.
+- Make your change or bug fix.
+- Send a Pull Request.
+- The team will review your change.
+- Add a [changeset](https://github.com/appsignal/mono/#changeset) to your Pull
+  Request for the [CHANGELOG](CHANGELOG.md).
+- If approved, a maintainer will merge your change.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2023 AppSignal
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,58 @@
 # AppSignal Python
 
+AppSignal solves all your Python monitoring needs in a single tool. You and
+your team can focus on writing code and we'll provide the alerts if your app
+has any issues.
+
+- [AppSignal.com website][appsignal]
+- [Documentation][python docs]
+- [Support][contact]
+
 [![PyPI - Version](https://img.shields.io/pypi/v/appsignal-beta.svg)](https://pypi.org/project/appsignal-beta)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/appsignal-beta.svg)](https://pypi.org/project/appsignal-beta)
 
------
+## Description
 
-**Table of Contents**
+The AppSignal package collects exceptions and performance data from your Ruby
+applications and sends it to AppSignal for analysis. Get alerted when an error
+occurs or an endpoint is responding very slowly.
 
-- [Installation](#installation)
-- [License](#license)
+## Usage
+
+First make sure you've installed AppSignal in your application by following the
+steps in [Installation](#installation).
+
+AppSignal will automatically monitor requests, report any exceptions that are
+thrown and any performance issues that might have occurred.
+
+You can also add extra information by adding custom instrumentation and by tags.
 
 ## Installation
 
-```console
-pip install appsignal-beta
-```
+Please follow our [installation guide] in our documentation. We try to
+automatically instrument as many packages as possible, but may not always be
+able to. Make to sure follow any [instructions to add manual
+instrumentation][manual instrumentation].
+
+[installation guide]: https://docs.appsignal.com/python/installation
+[manual instrumentation]: https://docs.appsignal.com/python/instrumentations
 
 ## Development
 
-AppSignal for Python uses [Hatch](https://hatch.pypa.io/latest/) to manage dependencies, packaging and development environments.
+AppSignal for Python uses [Hatch](https://hatch.pypa.io/latest/) to manage
+dependencies, packaging and development environments.
 
 ```sh
 pip install hatch
+```
+
+### Publishing
+
+Publishing is done using [mono](https://github.com/appsignal/mono/). Install it
+before development on the project.
+
+```sh
+mono publish
 ```
 
 ### Linting and type checking
@@ -68,3 +99,29 @@ hatch run build:me --keep-agent
 hatch clean # clean dist folder
 rm -r tmp # clean agent build cache
 ```
+
+## Contributing
+
+Thinking of contributing to our package? Awesome! 🚀
+
+Please follow our [Contributing guide][contributing-guide] in our
+documentation and follow our [Code of Conduct][coc].
+
+Also, we would be very happy to send you Stroopwafles. Have look at everyone
+we send a package to so far on our [Stroopwafles page][waffles-page].
+
+## Support
+
+[Contact us][contact] and speak directly with the engineers working on
+AppSignal. They will help you get set up, tweak your code and make sure you get
+the most out of using AppSignal.
+
+Also see our [SUPPORT.md file](SUPPORT.md).
+
+[appsignal]: https://www.appsignal.com
+[appsignal-sign-up]: https://appsignal.com/users/sign_up
+[contact]: mailto:support@appsignal.com
+[python docs]: https://docs.appsignal.com/python
+[semver]: http://semver.org/
+[waffles-page]: https://www.appsignal.com/waffles
+[coc]: https://docs.appsignal.com/appsignal/code-of-conduct.html

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,16 @@
+# Support
+
+[Contact us][contact] and speak directly with the engineers working on
+AppSignal. They will help you get set up, tweak your code and make sure you get
+the most out of using AppSignal. You can also find our documentation at
+[docs.appsignal.com](https://docs.appsignal.com/).
+
+We do not recommend creating an issue on the Python package's GitHub project if
+it concerns your private app data. During the support process we'll need the
+AppSignal logs and other resources that contain your app's private data,
+something for which the public GitHub issue tracker is not suited.
+
+Please contact us on our website [appsignal.com](https://appsignal.com/) or via
+email at [support@appsignal.com][contact].
+
+[contact]: mailto:support@appsignal.com


### PR DESCRIPTION
Update the README to follow our other project's structure. Add missing files to add a license, Code of Conduct and other files detected by GitHub.

[skip changeset]