### PR TITLE
Bump agent to version ff454dc

### DIFF
--- a/.changesets/add-support-for-asgi-frameworks.md
+++ b/.changesets/add-support-for-asgi-frameworks.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add support for OpenTelemetry instrumentation of ASGI-based frameworks, such as FastAPI and Starlette.

--- a/src/scripts/agent.py
+++ b/src/scripts/agent.py
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-    "version": "91f1a7c",
+    "version": "ff454dc",
     "mirrors": [
         "https://appsignal-agent-releases.global.ssl.fastly.net",
         "https://d135dj0rjqvssy.cloudfront.net",
@@ -12,131 +12,131 @@ APPSIGNAL_AGENT_CONFIG = {
     "triples": {
         "x86_64-darwin": {
             "static": {
-                "checksum": "c05dc1dd39862a709022681a6458de9137bb7bdf53f46ab0507029343cc09fef",
+                "checksum": "1d3c5957b4d6d60334dfbde94226053c067aa248701219027dbfd8d27c3a53d7",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "e15fc014c3d0fc55ada0c1aede241349a7dfc33e2d78523a576c76f95ead1cd1",
+                "checksum": "a68a9ee31ae25fa22353f02b13fdf70016e33a468f0e157fa69ad18d3c8f7a7d",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "universal-darwin": {
             "static": {
-                "checksum": "c05dc1dd39862a709022681a6458de9137bb7bdf53f46ab0507029343cc09fef",
+                "checksum": "1d3c5957b4d6d60334dfbde94226053c067aa248701219027dbfd8d27c3a53d7",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "e15fc014c3d0fc55ada0c1aede241349a7dfc33e2d78523a576c76f95ead1cd1",
+                "checksum": "a68a9ee31ae25fa22353f02b13fdf70016e33a468f0e157fa69ad18d3c8f7a7d",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-darwin": {
             "static": {
-                "checksum": "973305782e3e123436cc784325d59d00622d14bc066eb0935ce34fac2f998977",
+                "checksum": "8897804fd2b2edaf28c2248f0d03d6fbb009e725ec2cce25af009f6ffd7ab02a",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "cdeb358f6217d37a82204ef8e6a8503900f363b12b51263d6af1ebb233ba75d5",
+                "checksum": "694d93663e1cfea290f0a1f401abe406953fad2f722505ef8a9961c591303bb2",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm64-darwin": {
             "static": {
-                "checksum": "973305782e3e123436cc784325d59d00622d14bc066eb0935ce34fac2f998977",
+                "checksum": "8897804fd2b2edaf28c2248f0d03d6fbb009e725ec2cce25af009f6ffd7ab02a",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "cdeb358f6217d37a82204ef8e6a8503900f363b12b51263d6af1ebb233ba75d5",
+                "checksum": "694d93663e1cfea290f0a1f401abe406953fad2f722505ef8a9961c591303bb2",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm-darwin": {
             "static": {
-                "checksum": "973305782e3e123436cc784325d59d00622d14bc066eb0935ce34fac2f998977",
+                "checksum": "8897804fd2b2edaf28c2248f0d03d6fbb009e725ec2cce25af009f6ffd7ab02a",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "cdeb358f6217d37a82204ef8e6a8503900f363b12b51263d6af1ebb233ba75d5",
+                "checksum": "694d93663e1cfea290f0a1f401abe406953fad2f722505ef8a9961c591303bb2",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux": {
             "static": {
-                "checksum": "50a6f27614dea8867618c8677ebc2c67e3c095b3e7ca8580e60a0a75b12725c3",
+                "checksum": "13c5f9d70bd33c23d686fb9d6d80919a9b0eebbd98f85e88af63b47fa71f9c16",
                 "filename": "appsignal-aarch64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "3eec7a8d7e13c4b549e56377c73697ee1082777f01e8e32d6111b28957912fde",
+                "checksum": "9b8085ecc0c96c1f954410333d5f9e39ab6096178c965fc9a8da2a6834707e56",
                 "filename": "appsignal-aarch64-linux-all-dynamic.tar.gz",
             },
         },
         "i686-linux": {
             "static": {
-                "checksum": "1d1b3fdbfcb7f3388b16184f51c50d5eda17886b87214b1b81a281d876adb119",
+                "checksum": "8909a2beb5a3705a39d29603ecb7a4ea937cb25d5578ce1b6fbfbe456c1b855b",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "fd7d3c0348023283c6a97f7b38cc7ae61c11f9d9f0336864b6436901096da438",
+                "checksum": "98a703c8887aba12688026632f75300cea97ed212418641f5670d768bc3d5c54",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86-linux": {
             "static": {
-                "checksum": "1d1b3fdbfcb7f3388b16184f51c50d5eda17886b87214b1b81a281d876adb119",
+                "checksum": "8909a2beb5a3705a39d29603ecb7a4ea937cb25d5578ce1b6fbfbe456c1b855b",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "fd7d3c0348023283c6a97f7b38cc7ae61c11f9d9f0336864b6436901096da438",
+                "checksum": "98a703c8887aba12688026632f75300cea97ed212418641f5670d768bc3d5c54",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux": {
             "static": {
-                "checksum": "9bb4ddfca296c1fab82e12ca9a88bbe3ec29f6c2628a891eabcbf1506a20145b",
+                "checksum": "5f8dc335aabcf818f6fdfee0ef7fb60b922e569914384567564446badd7b99c6",
                 "filename": "appsignal-x86_64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "b22564cd5f4569c27eddef01627ecccf343b6c5584e788bdd7efa22d7314e972",
+                "checksum": "f1979752a1c448fec9c73e2fb2518ccbb390bae601875286660ed86aedb5feae",
                 "filename": "appsignal-x86_64-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux-musl": {
             "static": {
-                "checksum": "4222ae184a822bebff8453e221666e53c581c0bbc0fb9f2150aa6dc000b0d564",
+                "checksum": "ecfdbea74ef7c8b63891681daf9647b48873258707005306a535bb082a73a46c",
                 "filename": "appsignal-x86_64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "b1b771cba1a49e148d4180921c174584e2c8a8d8fc8b38ac10dc35523f152f3b",
+                "checksum": "8d08bb9a33dd25e0adb8bf3fd7fb2040022704c036ed1d96f722634b155b8f33",
                 "filename": "appsignal-x86_64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux-musl": {
             "static": {
-                "checksum": "531f036405796bdf4b1aefe91680f5009fa0f3a69c306937895248f6d50f74c5",
+                "checksum": "94781152e98f1c565858834897322bb3097d9d875ea1294e32981f6a3e614902",
                 "filename": "appsignal-aarch64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "d9af4e7734451a7b3cf00016016ddbf2d6a59407db028d6a998d17e654e7524c",
+                "checksum": "ab20ab210a9302e7e7b56bb5ac5b2136faf1b0724a8e5bb516d7d6db828365ba",
                 "filename": "appsignal-aarch64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "x86_64-freebsd": {
             "static": {
-                "checksum": "cc3c873d8dacfea995660b0fd931eacd9d479b3bc2f78d8a70cf9ac384e7f7d6",
+                "checksum": "3731c19f246b344bb5f6cd069294e1666d7ce982acd9bf8e9ab7ff9e899878de",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "da332e442c7e1a306b8227dc09ad4ef25d523c8aea50cdf01048ab3e8e56cf9c",
+                "checksum": "59c70f101e789d06bb40a6c1ecb45518c9f90a8b2e09eef5188c63024d8466f1",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },
         "amd64-freebsd": {
             "static": {
-                "checksum": "cc3c873d8dacfea995660b0fd931eacd9d479b3bc2f78d8a70cf9ac384e7f7d6",
+                "checksum": "3731c19f246b344bb5f6cd069294e1666d7ce982acd9bf8e9ab7ff9e899878de",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "da332e442c7e1a306b8227dc09ad4ef25d523c8aea50cdf01048ab3e8e56cf9c",
+                "checksum": "59c70f101e789d06bb40a6c1ecb45518c9f90a8b2e09eef5188c63024d8466f1",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },


### PR DESCRIPTION
Closes #10.

Adds support for ASGI-based frameworks, such as FastAPI and Starlette.