### PR TITLE
Mypy config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,10 +82,13 @@ dependencies = [
   "opentelemetry-sdk",
   "opentelemetry-exporter-otlp-proto-http",
   "docopt",
+  "types-deprecated",
+  "types-docopt",
+  "types-requests",
 ]
 
 [tool.hatch.envs.lint.scripts]
-typing = "mypy --install-types --non-interactive --check-untyped-defs --enable-incomplete-feature=Unpack {args:src tests}"
+typing = "mypy --enable-incomplete-feature=Unpack {args}"
 style = [
   "ruff {args:.}",
   "black --check --diff {args:.}",
@@ -129,6 +132,10 @@ exclude_lines = [
   "if __name__ == .__main__.:",
   "if TYPE_CHECKING:",
 ]
+
+[tool.mypy]
+files = ["src", "tests"]
+check_untyped_defs = true
 
 [[tool.mypy.overrides]]
 module = "opentelemetry.instrumentation.*"

--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -8,7 +8,7 @@ from .opentelemetry import start_opentelemetry
 from .config import Config, Options
 
 if TYPE_CHECKING:
-    from typing import Unpack
+    from typing_extensions import Unpack
 
 
 class Client:


### PR DESCRIPTION
1. Use config for mypy options, so that the IDE and `hatch run lint:typing` produce the same results. The `--enable-incomplete-feature` flag statys, though, I don't think there is a config option for that.
1. Resolve mypy violation by importing Unpack from typing_extension. You don't need to install typing_extension for that to work, myp ships with stubs for it.
1. Explicitly list mypy dependencies instead of using `--install-types`. Let your package manager deal with packages. It's faster, it's explicit, it's reliable.