### PR TITLE
Sort all imports using isort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 /dist
 /src/appsignal/appsignal-agent
 /tmp
+/.coverage

--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,10 @@
-import os
 import logging
-import pytest
+import os
 import platform
 import tempfile
+
+import pytest
+
 from appsignal.agent import _reset_agent_active
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,11 @@ exclude_lines = [
   "if TYPE_CHECKING:",
 ]
 
+[tool.isort]
+profile = "black"
+lines_after_imports = 2
+line_length = 88
+
 [tool.mypy]
 files = ["src", "tests"]
 check_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ detached = true
 dependencies = [
   "black>=23.1.0",
   "mypy>=1.0.0",
+  "isort",
   "ruff>=0.0.243",
   "hatchling", # needed for type checking
   "opentelemetry-api",
@@ -91,9 +92,11 @@ dependencies = [
 typing = "mypy --enable-incomplete-feature=Unpack {args}"
 style = [
   "ruff {args:.}",
+  "isort --check {args:.}",
   "black --check --diff {args:.}",
 ]
 fmt = [
+  "isort {args:.}",
   "black {args:.}",
   "ruff --fix {args:.}",
 ]

--- a/src/appsignal/__init__.py
+++ b/src/appsignal/__init__.py
@@ -1,3 +1,4 @@
 from .client import Client as Appsignal
 
+
 __all__ = ["Appsignal"]

--- a/src/appsignal/agent.py
+++ b/src/appsignal/agent.py
@@ -5,6 +5,7 @@ import subprocess
 
 from .config import Config
 
+
 AGENT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "appsignal-agent")
 agent_active = False
 

--- a/src/appsignal/cli/base.py
+++ b/src/appsignal/cli/base.py
@@ -1,10 +1,9 @@
 from docopt import docopt
 
 from ..__about__ import __version__
-
 from .command import AppsignalCLICommand
-from .install import InstallCommand
 from .demo import DemoCommand
+from .install import InstallCommand
 
 
 DOC = """AppSignal for Python CLI.

--- a/src/appsignal/cli/command.py
+++ b/src/appsignal/cli/command.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-
 from typing import Optional
 
 

--- a/src/appsignal/cli/demo.py
+++ b/src/appsignal/cli/demo.py
@@ -1,9 +1,9 @@
-import os
 import json
-
-from appsignal.client import Client
+import os
 
 from opentelemetry import trace
+
+from appsignal.client import Client
 
 from .command import AppsignalCLICommand
 

--- a/src/appsignal/cli/install.py
+++ b/src/appsignal/cli/install.py
@@ -1,10 +1,12 @@
-import requests
 import os
+
+import requests
+
+from appsignal.config import Config
 
 from .command import AppsignalCLICommand
 from .demo import DemoCommand
 
-from appsignal.config import Config
 
 INSTALL_FILE_TEMPLATE = """from appsignal import Appsignal
 

--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
-import sys
+
 import logging
-from logging import Logger, ERROR, WARNING, INFO, DEBUG
+import sys
+from logging import DEBUG, ERROR, INFO, WARNING, Logger
+from typing import TYPE_CHECKING
+
 from .agent import start_agent
-from .opentelemetry import start_opentelemetry
 from .config import Config, Options
+from .opentelemetry import start_opentelemetry
+
 
 if TYPE_CHECKING:
     from typing_extensions import Unpack

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
-from .__about__ import __version__
-from typing import List
 
 import os
 import platform
 import tempfile
-from typing import TYPE_CHECKING, cast, get_args, TypedDict, Union, Optional, Literal
+from typing import (
+    TYPE_CHECKING,
+    List,
+    Literal,
+    Optional,
+    TypedDict,
+    Union,
+    cast,
+    get_args,
+)
+
+from .__about__ import __version__
+
 
 if TYPE_CHECKING:
     pass

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
-import os
-from typing import Dict
+
 import logging
-
-from .config import Config, list_to_env_str
-
-from typing import Callable
+import os
+from typing import Callable, Dict
 
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+from .config import Config, list_to_env_str
 
 
 def add_celery_instrumentation() -> None:
@@ -20,8 +19,9 @@ def add_celery_instrumentation() -> None:
 
 
 def add_django_instrumentation() -> None:
-    from opentelemetry.instrumentation.django import DjangoInstrumentor
     import json
+
+    from opentelemetry.instrumentation.django import DjangoInstrumentor
 
     def response_hook(span, request, response) -> None:
         span.set_attribute(
@@ -33,9 +33,10 @@ def add_django_instrumentation() -> None:
 
 
 def add_flask_instrumentation() -> None:
-    from opentelemetry.instrumentation.flask import FlaskInstrumentor
     import json
     from urllib.parse import parse_qs
+
+    from opentelemetry.instrumentation.flask import FlaskInstrumentor
 
     def request_hook(span, environ) -> None:
         if span and span.is_recording():

--- a/src/scripts/build_hook.py
+++ b/src/scripts/build_hook.py
@@ -1,13 +1,12 @@
-from typing import Any
-from runpy import run_path
-from typing import Dict
-import os
-import stat
 import hashlib
-import tarfile
+import os
 import shutil
-import sysconfig
+import stat
 import subprocess
+import sysconfig
+import tarfile
+from runpy import run_path
+from typing import Any, Dict
 
 import requests
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface

--- a/src/scripts/sdist_hook.py
+++ b/src/scripts/sdist_hook.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict
+
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,8 @@
-from contextlib import contextmanager
 import builtins
-
+from contextlib import contextmanager
 from typing import cast
 from unittest.mock import MagicMock
+
 
 EXPECTED_FILE_CONTENTS = """from appsignal import Appsignal
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,9 @@
-from appsignal.client import Client
-from appsignal.agent import is_agent_active
-
 import os
 import re
-from logging import ERROR, WARNING, INFO, DEBUG
+from logging import DEBUG, ERROR, INFO, WARNING
+
+from appsignal.agent import is_agent_active
+from appsignal.client import Client
 
 
 def test_client_options_merge_sources():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 import os
-from appsignal.__about__ import __version__
 
+from appsignal.__about__ import __version__
 from appsignal.config import Config, Options
 
 

--- a/tests/test_opentelemetry.py
+++ b/tests/test_opentelemetry.py
@@ -1,5 +1,5 @@
-from unittest.mock import Mock
 from typing import Dict
+from unittest.mock import Mock
 
 from appsignal.config import Config, Options
 from appsignal.opentelemetry import add_instrumentations


### PR DESCRIPTION
[isort](https://pycqa.github.io/isort/) is a code formatter for sorting and grouping python imports. The PR add isort into `lint` dependencies and uses it to sort all imports.