### PR TITLE
Improve coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 /dist
 /src/appsignal/appsignal-agent
 /tmp
+/htmlcov/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,12 @@ appsignal = "appsignal.cli.base:run"
 pythonpath = [
   "src"
 ]
+addopts = [
+  "--cov-report=term-missing",
+  "--cov-report=html",
+  "--cov=src/appsignal",
+  "--cov-fail-under=84",
+]
 
 [tool.hatch.version]
 path = "src/appsignal/__about__.py"
@@ -64,9 +70,6 @@ dependencies = [
   "pytest-cov",
   "pytest-mock",
 ]
-[tool.hatch.envs.default.scripts]
-cov = "pytest --cov-report=term-missing --cov=src/appsignal --cov-fail-under=84 {args}"
-no-cov = "cov --no-cov {args}"
 
 [[tool.hatch.envs.test.matrix]]
 python = ["38", "39", "310", "311"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
   "pytest-mock",
 ]
 [tool.hatch.envs.default.scripts]
-cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=src --cov=tests {args}"
+cov = "pytest --cov-report=term-missing --cov=src/appsignal --cov-fail-under=84 {args}"
 no-cov = "cov --no-cov {args}"
 
 [[tool.hatch.envs.test.matrix]]
@@ -131,6 +131,7 @@ exclude_lines = [
   "no cov",
   "if __name__ == .__main__.:",
   "if TYPE_CHECKING:",
+  "raise NotImplementedError",
 ]
 
 [tool.mypy]

--- a/src/appsignal/cli/base.py
+++ b/src/appsignal/cli/base.py
@@ -42,5 +42,4 @@ def command_for(arguments) -> AppsignalCLICommand:
             push_api_key=arguments["--push-api-key"],
             application=arguments["--application"],
         )
-    else:
-        raise NotImplementedError
+    raise NotImplementedError

--- a/src/appsignal/cli/command.py
+++ b/src/appsignal/cli/command.py
@@ -6,7 +6,7 @@ from typing import Optional
 class AppsignalCLICommand(ABC):
     @abstractmethod
     def run(self) -> int:
-        raise
+        raise NotImplementedError
 
     _push_api_key: Optional[str]
     _name: Optional[str]


### PR DESCRIPTION
1. Exclude `tests` and `src/scripts` from the coverage report. Calculate coverage only for `src/appsignal`.
1. Set minimal coverage.
1. Calculate coverage even when running pytest without any options.
1. Produce HTML coverage report.
1. Remove undocumented `cov` and `no-cov` hatch commands in favor of `test:pytest` used on CI and described in the README.
