### PR TITLE
Diagnose command

### DIFF
--- a/.changesets/add-diagnose-command.md
+++ b/.changesets/add-diagnose-command.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add diagnose command

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/diagnose"]
+	path = tests/diagnose
+	url = https://github.com/appsignal/diagnose_tests.git

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,6 +31,15 @@ blocks:
   dependencies: []
   task:
     jobs:
+    - name: Diagnose tests
+      env_vars:
+        - name: LANGUAGE
+          value: python
+      commands:
+        - "sem-version python 3.11"
+        - git submodule init
+        - git submodule update
+        - ./tests/diagnose/bin/test
     - name: Python 3.8
       commands:
       - "sem-version python 3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ branch = true
 parallel = true
 omit = [
   "src/appsignal/__about__.py",
+  "src/appsignal/cli/diagnose.py",
   "src/scripts",
 ]
 

--- a/src/appsignal/agent.py
+++ b/src/appsignal/agent.py
@@ -28,5 +28,8 @@ class Agent:
             out = output.decode("utf-8")
             print(f"AppSignal agent is unable to start ({returncode}): ", out)
 
+    def diagnose(self) -> str:
+        return subprocess.run([self.path, "diagnose"], capture_output=True).stdout
+
 
 agent = Agent()

--- a/src/appsignal/agent.py
+++ b/src/appsignal/agent.py
@@ -28,7 +28,7 @@ class Agent:
             out = output.decode("utf-8")
             print(f"AppSignal agent is unable to start ({returncode}): ", out)
 
-    def diagnose(self) -> str:
+    def diagnose(self) -> bytes:
         return subprocess.run([self.path, "diagnose"], capture_output=True).stdout
 
 

--- a/src/appsignal/agent.py
+++ b/src/appsignal/agent.py
@@ -31,5 +31,10 @@ class Agent:
     def diagnose(self) -> bytes:
         return subprocess.run([self.path, "diagnose"], capture_output=True).stdout
 
+    def version(self) -> bytes:
+        return subprocess.run(
+            [self.path, "--version"], capture_output=True
+        ).stdout.split()[-1]
+
 
 agent = Agent()

--- a/src/appsignal/cli/base.py
+++ b/src/appsignal/cli/base.py
@@ -6,6 +6,7 @@ from typing import Mapping, NoReturn
 
 from .command import AppsignalCLICommand
 from .demo import DemoCommand
+from .diagnose import DiagnoseCommand
 from .install import InstallCommand
 from .version import VersionCommand
 
@@ -14,6 +15,7 @@ COMMANDS: Mapping[str, type[AppsignalCLICommand]] = {
     "demo": DemoCommand,
     "install": InstallCommand,
     "version": VersionCommand,
+    "diagnose": DiagnoseCommand,
 }
 
 

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -1,9 +1,12 @@
+# ruff: noqa: E501
+
 import json
 import os
 import platform
 import urllib
 from argparse import ArgumentParser
 from pathlib import Path
+from typing import Any, Optional
 
 import requests
 
@@ -16,59 +19,55 @@ from .command import AppsignalCLICommand
 
 
 class AgentReport:
-    def __init__(self, report):
+    def __init__(self, report: dict) -> None:
         self.report = report
 
-    def extension_loaded(self):
+    def extension_loaded(self) -> str:
         return self.report["boot"]["started"]["result"]
 
-    def configuration_valid(self):
+    def configuration_valid(self) -> str:
         if self.report["config"]["valid"]["result"]:
             return "valid"
-        else:
-            return "invalid"
+        return "invalid"
 
-    def started(self):
+    def started(self) -> str:
         if self.report["boot"]["started"]["result"]:
             return "started"
-        else:
-            return "not started"
+        return "not started"
 
-    def user_id(self):
+    def user_id(self) -> str:
         return self.report["host"]["uid"]["result"]
 
-    def group_id(self):
+    def group_id(self) -> str:
         return self.report["host"]["gid"]["result"]
 
-    def logger_started(self):
+    def logger_started(self) -> str:
         if "logger" in self.report and self.report["logger"]["started"]["result"]:
             return "started"
-        else:
-            return "not started"
+        return "not started"
 
-    def working_directory_user_id(self):
+    def working_directory_user_id(self) -> bool:
         return (
             "working_directory_stat" in self.report
             and self.report["working_directory_stat"]["uid"]["result"]
         )
 
-    def working_directory_group_id(self):
+    def working_directory_group_id(self) -> bool:
         return (
             "working_directory_stat" in self.report
             and self.report["working_directory_stat"]["gid"]["result"]
         )
 
-    def working_directory_permissions(self):
+    def working_directory_permissions(self) -> bool:
         return (
             "working_directory_stat" in self.report
             and self.report["working_directory_stat"]["mode"]["result"]
         )
 
-    def lock_path(self):
+    def lock_path(self) -> str:
         if "lock_path" in self.report and self.report["lock_path"]["created"]["result"]:
             return "writable"
-        else:
-            return "not writable"
+        return "not writable"
 
 
 class DiagnoseCommand(AppsignalCLICommand):
@@ -85,7 +84,7 @@ class DiagnoseCommand(AppsignalCLICommand):
             help="Do not send the report to AppSignal",
         )
 
-    def run(self):
+    def run(self) -> int:
         agent = Agent()
         self.config = Config()
         self.send_report = self.args.send_report
@@ -144,7 +143,9 @@ class DiagnoseCommand(AppsignalCLICommand):
         if self.no_send_report:
             print("Not sending report. (Specified with the --no-send-report option.)")
 
-    def _header(self):
+        return 0
+
+    def _header(self) -> None:
         print("AppSignal diagnose")
         print("=" * 80)
         print("Use this information to debug your configuration.")
@@ -153,16 +154,16 @@ class DiagnoseCommand(AppsignalCLICommand):
         print("Send this output to support@appsignal.com if you need help.")
         print("=" * 80)
 
-    def _library_information(self):
-        library_report = self.report["library"]
+    def _library_information(self) -> None:
+        library_report: Any = self.report["library"]
         print("AppSignal library")
         print("  Language: Python")
         print(f'  Package version: "{library_report["package_version"]}"')
         print(f'  Agent version: "{library_report["agent_version"]}"')
         print(f'  Extension loaded: {library_report["extension_loaded"]}')
 
-    def _host_information(self):
-        host_report = self.report["host"]
+    def _host_information(self) -> None:
+        host_report: Any = self.report["host"]
         print("Host information")
         print(f'  Architecture: "{host_report["architecture"]}"')
         print(f'  Operating System: "{host_report["os"]}"')
@@ -170,7 +171,7 @@ class DiagnoseCommand(AppsignalCLICommand):
         print(f'  Root user: {host_report["root"]}')
         print(f'  Running in container: {host_report["running_in_container"]}')
 
-    def _agent_information(self):
+    def _agent_information(self) -> None:
         print("Agent diagnostics")
         print("  Extension tests")
         print(f"    Configuration: {self.agent_report.configuration_valid()}")
@@ -191,28 +192,28 @@ class DiagnoseCommand(AppsignalCLICommand):
         )
         print(f"    Lock path: {self.agent_report.lock_path()}")
 
-    def _configuration_information(self):
+    def _configuration_information(self) -> None:
         print("Configuration")
 
         for key in self.config.options:
-            print(f"  {key}: {repr(self.config.options[key])}")
+            print(f"  {key}: {self.config.options[key]!r}")  # type: ignore
 
         print()
         print("Read more about how the diagnose config output is rendered")
         print("https://docs.appsignal.com/python/command-line/diagnose.html")
 
-    def _validation_information(self):
-        validation_report = self.report["validation"]
+    def _validation_information(self) -> None:
+        validation_report: Any = self.report["validation"]
         print("Validation")
         print(f'  Validating Push API key: {validation_report["push_api_key"]}')
 
-    def _paths_information(self):
+    def _paths_information(self) -> None:
         print("Paths")
 
-    def _report_information(self):
+    def _report_information(self) -> None:
         print("Diagnostics report")
 
-    def _report_prompt(self):
+    def _report_prompt(self) -> bool | None:
         print("  Do you want to send this diagnostics report to AppSignal?")
         print("  If you share this report you will be given a link to")
         print("  AppSignal.com to validate the report.")
@@ -228,9 +229,10 @@ class DiagnoseCommand(AppsignalCLICommand):
                 print("Not sending diagnostics information to AppSignal.")
                 return False
             case _:
-                report_prompt()
+                self._report_prompt()
+                return None
 
-    def _send_diagnose_report(self):
+    def _send_diagnose_report(self) -> None:
         params = urllib.parse.urlencode(
             {
                 "api_key": self.config.option("push_api_key"),
@@ -258,13 +260,13 @@ class DiagnoseCommand(AppsignalCLICommand):
             print(f"  Response code: {status}")
             print(f"  Response body: {response.text}")
 
-    def _os_distribution(self):
+    def _os_distribution(self) -> str:
         try:
-            return platform.freedesktop_os_release()
+            return platform.freedesktop_os_release()["NAME"]
         except OSError:
             return ""
 
-    def _validate_push_api_key(self):
+    def _validate_push_api_key(self) -> str:
         match PushApiKeyValidator.validate(self.config):
             case "valid":
                 return "valid"

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -7,7 +7,6 @@ import os
 import platform
 import urllib
 from argparse import ArgumentParser
-from pathlib import Path
 from typing import Any
 
 import requests

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -55,7 +55,10 @@ class AgentReport:
         return self.report["working_directory_stat"]["mode"]["result"]
 
     def lock_path(self):
-        return self.report["lock_path"]["created"]["result"]
+        if self.report["lock_path"]["created"]["result"]:
+            return "writable"
+        else:
+            return "not writable"
 
 
 class DiagnoseCommand(AppsignalCLICommand):

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -46,32 +46,33 @@ class AgentReport:
         return self.report["host"]["gid"]["result"]
 
     def logger_started(self) -> str:
-        if "logger" in self.report and self.report["logger"]["started"]["result"]:
-            return "started"
-        return "not started"
+        if "logger" in self.report:
+            if self.report["logger"]["started"]["result"]:
+                return "started"
+            return "not started"
+        return "-"
 
-    def working_directory_user_id(self) -> bool:
-        return (
-            "working_directory_stat" in self.report
-            and self.report["working_directory_stat"]["uid"]["result"]
-        )
+    def working_directory_user_id(self) -> str:
+        if "working_directory_stat" in self.report:
+            return self.report["working_directory_stat"]["uid"]["result"]
+        return "-"
 
-    def working_directory_group_id(self) -> bool:
-        return (
-            "working_directory_stat" in self.report
-            and self.report["working_directory_stat"]["gid"]["result"]
-        )
+    def working_directory_group_id(self) -> str:
+        if "working_directory_stat" in self.report:
+            return self.report["working_directory_stat"]["gid"]["result"]
+        return "-"
 
-    def working_directory_permissions(self) -> bool:
-        return (
-            "working_directory_stat" in self.report
-            and self.report["working_directory_stat"]["mode"]["result"]
-        )
+    def working_directory_permissions(self) -> str:
+        if "working_directory_stat" in self.report:
+            return self.report["working_directory_stat"]["mode"]["result"]
+        return "-"
 
     def lock_path(self) -> str:
-        if "lock_path" in self.report and self.report["lock_path"]["created"]["result"]:
-            return "writable"
-        return "not writable"
+        if "lock_path" in self.report:
+            if self.report["lock_path"]["created"]["result"]:
+                return "writable"
+            return "not writable"
+        return "-"
 
 
 class DiagnoseCommand(AppsignalCLICommand):

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -9,6 +9,7 @@ import requests
 
 from appsignal.agent import Agent
 from appsignal.config import Config
+from appsignal.push_api_key_validator import PushApiKeyValidator
 
 from ..__about__ import __version__
 from .command import AppsignalCLICommand
@@ -117,7 +118,7 @@ class DiagnoseCommand(AppsignalCLICommand):
             },
             "paths": None,
             "process": None,
-            "validation": None,
+            "validation": {"push_api_key": self._validate_push_api_key()},
         }
 
         self._header()
@@ -205,7 +206,9 @@ class DiagnoseCommand(AppsignalCLICommand):
         print("https://docs.appsignal.com/python/command-line/diagnose.html")
 
     def _validation_information(self):
+        validation_report = self.report["validation"]
         print("Validation")
+        print(f'  Validating Push API key: {validation_report["push_api_key"]}')
 
     def _paths_information(self):
         print("Paths")
@@ -242,3 +245,12 @@ class DiagnoseCommand(AppsignalCLICommand):
             return platform.freedesktop_os_release()
         except OSError:
             return ""
+
+    def _validate_push_api_key(self):
+        match PushApiKeyValidator.validate(self.config):
+            case "valid":
+                return "valid"
+            case "invalid":
+                return "invalid"
+            case value:
+                return f"Failed to validate: {value}"

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -125,8 +125,6 @@ class DiagnoseCommand(AppsignalCLICommand):
                 "os": platform.system().lower(),
                 "os_distribution": self._os_distribution(),
                 "root": os.getuid() == 0,
-                "running_in_container": self.config.option("running_in_container")
-                is not None,
             },
             "library": {
                 "language": "python",
@@ -193,7 +191,6 @@ class DiagnoseCommand(AppsignalCLICommand):
         print(f'  Operating System: "{host_report["os"]}"')
         print(f'  Python version: "{host_report["language_version"]}"')
         print(f'  Root user: {host_report["root"]}')
-        print(f'  Running in container: {host_report["running_in_container"]}')
 
     def _agent_information(self) -> None:
         print("Agent diagnostics")

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -37,7 +37,15 @@ class DiagnoseCommand(AppsignalCLICommand):
         self.report = {
             "agent": None,
             "config": None,
-            "host": None,
+            "host": {
+                "architecture": platform.platform(),
+                "heroku": os.environ.get("DYNO") is not None,
+                "language_version": platform.python_version(),
+                "os": platform.system().lower(),
+                "os_distribution": "",
+                "root": False,
+                "running_in_container": self.config.option("running_in_container") is not None
+            },
             "library": {
                 "language": "python",
                 "package_version": __version__,
@@ -93,13 +101,13 @@ class DiagnoseCommand(AppsignalCLICommand):
         print(f'  Extension loaded: {library_report["extension_loaded"]}')
 
     def _host_information(self):
+        host_report = self.report["host"]
         print("Host information")
-        print(f"  Architecture: {platform.platform()}")
-        print(f"  Operating System: {platform.system()} {platform.release()}")
-        print(f"  Python version: {platform.python_version()}")
-        print(f"  Root user: {os.getuid() == 0}")
-        running_in_container = self.config.option("running_in_container")
-        print(f"  Running in container: {running_in_container}")
+        print(f'  Architecture: "{host_report["architecture"]}"')
+        print(f'  Operating System: "{host_report["os"]}"')
+        print(f'  Python version: "{host_report["language_version"]}"')
+        print(f'  Root user: {host_report["root"]}')
+        print(f'  Running in container: {host_report["running_in_container"]}')
 
     def _agent_information(self):
         print("Agent diagnostics")

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -35,6 +35,16 @@ class DiagnoseCommand(AppsignalCLICommand):
         self.config = Config()
         self.send_report = self.args.send_report
         self.no_send_report = self.args.no_send_report
+        self.report = {
+                'agent': None,
+                'config': None,
+                'host': None,
+                'installation': None,
+                'library': {},
+                'paths': None,
+                'process': None,
+                'validation': None,
+        }
         self.agent_report = json.loads(agent.diagnose())
 
         self._header()
@@ -131,15 +141,4 @@ class DiagnoseCommand(AppsignalCLICommand):
         endpoint = self.config.option("diagnose_endpoint")
         url = f"{endpoint}?{params}"
 
-        response = requests.post(url, json={
-            'diagnose': {
-                'agent': None,
-                'config': None,
-                'host': None,
-                'installation': None,
-                'library': None,
-                'paths': None,
-                'process': None,
-                'validation': None,
-            }
-        })
+        response = requests.post(url, json={'diagnose': self.report})

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -46,7 +46,8 @@ class DiagnoseCommand(AppsignalCLICommand):
         self._report_information()
         print()
 
-        self._send_diagnose_report()
+        if(self._report_prompt()):
+            self._send_diagnose_report()
 
     def _header(self):
         print("AppSignal diagnose")
@@ -90,6 +91,15 @@ class DiagnoseCommand(AppsignalCLICommand):
 
     def _report_information(self):
         print(f"Diagnostics report")
+
+    def _report_prompt(self):
+      match input("  Send diagnostics report to AppSignal? (Y/n):"):
+        case "y" | "yes" | "":
+            return True
+        case "n" | "no" :
+            return False
+        case _:
+            report_prompt()
 
     def _send_diagnose_report(self):
         params = urllib.parse.urlencode(

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -131,7 +131,7 @@ class DiagnoseCommand(AppsignalCLICommand):
             "library": {
                 "language": "python",
                 "package_version": __version__,
-                "agent_version": "91f1a7c",
+                "agent_version": str(agent.version(), "utf-8"),
             },
             "paths": self._paths_data(),
             "process": {

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -103,7 +103,10 @@ class DiagnoseCommand(AppsignalCLICommand):
                     "working_directory_stat": agent_json["working_directory_stat"],
                 }
             },
-            "config": None,
+            "config": {
+               "options": self.config.options,
+               "sources": self.config.sources,
+            },
             "host": {
                 "architecture": platform.machine(),
                 "heroku": os.environ.get("DYNO") is not None,

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -259,7 +259,7 @@ class DiagnoseCommand(AppsignalCLICommand):
         print("  with your support token.")
         print()
 
-        send_report = input("  Send diagnostics report to AppSignal? (Y/n):   ")
+        send_report = input("  Send diagnostics report to AppSignal? (Y/n):   ").lower()
 
         if send_report in ["y", "yes", ""]:
             print("Transmitting diagnostics report")

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -55,7 +55,7 @@ class DiagnoseCommand(AppsignalCLICommand):
     def _library_information(self):
         print("AppSignal library")
         print("  Language: Python")
-        print(f"  Package version: {__version__}")
+        print(f"  Package version: \"{__version__}\"")
         print(f"  Agent version: ")
 
     def _installation_information(self):

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -1,0 +1,50 @@
+import platform
+import os
+
+from pathlib import Path
+
+from .command import AppsignalCLICommand
+from appsignal.config import Config
+
+from ..__about__ import __version__
+
+class DiagnoseCommand(AppsignalCLICommand):
+    def __init__(self):
+        self.config = Config()
+
+    def run(self):
+        self._header()
+
+        self._library_information()
+        print()
+
+        self._host_information()
+        print()
+
+    def _header(self):
+        print("AppSignal diagnose")
+        print("=" * 80)
+        print("Use this information to debug your configuration.")
+        print("More information is available on the documentation site.")
+        print("https://docs.appsignal.com/")
+        print("Send this output to support@appsignal.com if you need help.")
+        print("=" * 80)
+
+    def _library_information(self):
+        print("AppSignal library")
+        print("  Language: Python")
+        print(f"  Package version: {__version__}")
+        print(f"  Agent version: ")
+
+    def _host_information(self):
+        print("Host information")
+        print(f"  Architecture: {platform.platform()}")
+        print(f"  Operating System: {platform.system()} {platform.release()}")
+        print(f"  Python version: {platform.python_version()}")
+        print(f"  Root user: {os.getuid() == 0}")
+        running_in_container = self.config.option("running_in_container")
+        print(f"  Running in container: {running_in_container)}")
+
+    def _get_agent_version(self):
+
+

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -143,7 +143,6 @@ class DiagnoseCommand(AppsignalCLICommand):
         print()
 
         self._report_information()
-        print()
 
         if self.send_report or (not self.no_send_report and self._report_prompt()):
             self._send_diagnose_report()
@@ -220,10 +219,19 @@ class DiagnoseCommand(AppsignalCLICommand):
         print("Diagnostics report")
 
     def _report_prompt(self):
-        match input("  Send diagnostics report to AppSignal? (Y/n):"):
+        print("  Do you want to send this diagnostics report to AppSignal?")
+        print("  If you share this report you will be given a link to")
+        print("  AppSignal.com to validate the report.")
+        print("  You can also contact us at support@appsignal.com")
+        print("  with your support token.")
+        print()
+
+        match input("  Send diagnostics report to AppSignal? (Y/n):   "):
             case "y" | "yes" | "":
+                print("Transmitting diagnostics report")
                 return True
             case "n" | "no":
+                print("Not sending diagnostics information to AppSignal.")
                 return False
             case _:
                 report_prompt()
@@ -246,6 +254,7 @@ class DiagnoseCommand(AppsignalCLICommand):
         status = response.status_code
         if status == 200:
             token = response.json()["token"]
+            print()
             print(f'  Your support token: {token}')
             print(f'  View this report:   https://appsignal.com/diagnose/{token}')
         else:

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -117,7 +117,7 @@ class DiagnoseCommand(AppsignalCLICommand):
                 "language_version": platform.python_version(),
                 "os": platform.system().lower(),
                 "os_distribution": self._os_distribution(),
-                "root": False,
+                "root": os.getuid() == 0,
                 "running_in_container": self.config.option("running_in_container")
                 is not None,
             },

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -146,9 +146,7 @@ class DiagnoseCommand(AppsignalCLICommand):
         print()
 
         if self.send_report or (not self.no_send_report and self._report_prompt()):
-            token = self._send_diagnose_report()
-            print(f'  Your support token: {token}')
-            print(f'  View this report:   https://appsignal.com/diagnose/{token}')
+            self._send_diagnose_report()
 
         if self.no_send_report:
             print("Not sending report. (Specified with the --no-send-report option.)")
@@ -244,7 +242,16 @@ class DiagnoseCommand(AppsignalCLICommand):
         url = f"{endpoint}?{params}"
 
         response = requests.post(url, json={"diagnose": self.report})
-        return response.json()["token"]
+
+        status = response.status_code
+        if status == 200:
+            token = response.json()["token"]
+            print(f'  Your support token: {token}')
+            print(f'  View this report:   https://appsignal.com/diagnose/{token}')
+        else:
+            print("  Error: Something went wrong while submitting the report to AppSignal.")
+            print(f'  Response code: {status}')
+            print(f'  Response body: {response.text}')
 
     def _os_distribution(self):
         try:

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -51,7 +51,7 @@ class DiagnoseCommand(AppsignalCLICommand):
         self._report_information()
         print()
 
-        if(self._report_prompt()):
+        if(self.send_report or self._report_prompt()):
             self._send_diagnose_report()
 
     def _header(self):

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -2,11 +2,15 @@ import os
 import platform
 import urllib
 from argparse import ArgumentParser
+import requests
+import json
+
 from pathlib import Path
 
 import requests
 
 from appsignal.config import Config
+from appsignal.agent import Agent
 
 from ..__about__ import __version__
 from .command import AppsignalCLICommand
@@ -27,9 +31,11 @@ class DiagnoseCommand(AppsignalCLICommand):
         )
 
     def run(self):
+        agent = Agent()
         self.config = Config()
         self.send_report = self.args.send_report
         self.no_send_report = self.args.no_send_report
+        self.agent_report = json.loads(agent.diagnose())
 
         self._header()
 
@@ -74,7 +80,7 @@ class DiagnoseCommand(AppsignalCLICommand):
         print("  Language: Python")
         print(f'  Package version: "{__version__}"')
         print(f'  Agent version: "91f1a7c"')
-        print(f"  Extension loaded: true")
+        print(f"  Extension loaded: {self.agent_report['boot']['started']['result']}")
 
     def _installation_information(self):
         print("Extension installation report")

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -57,6 +57,7 @@ class DiagnoseCommand(AppsignalCLICommand):
         print("  Language: Python")
         print(f"  Package version: \"{__version__}\"")
         print(f"  Agent version: ")
+        print(f"  Extension loaded: ")
 
     def _installation_information(self):
         print("Extension installation report")

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -24,9 +24,6 @@ class AgentReport:
     def __init__(self, report: dict) -> None:
         self.report = report
 
-    def extension_loaded(self) -> str:
-        return self.report["boot"]["started"]["result"]
-
     def configuration_valid(self) -> str:
         if self.report["config"]["valid"]["result"]:
             return "valid"
@@ -128,7 +125,6 @@ class DiagnoseCommand(AppsignalCLICommand):
                 "language": "python",
                 "package_version": __version__,
                 "agent_version": "91f1a7c",
-                "extension_loaded": self.agent_report.extension_loaded(),
             },
             "paths": self._paths_data(),
             "process": None,
@@ -181,7 +177,6 @@ class DiagnoseCommand(AppsignalCLICommand):
         print("  Language: Python")
         print(f'  Package version: "{library_report["package_version"]}"')
         print(f'  Agent version: "{library_report["agent_version"]}"')
-        print(f'  Extension loaded: {library_report["extension_loaded"]}')
 
     def _host_information(self) -> None:
         host_report: Any = self.report["host"]
@@ -194,15 +189,13 @@ class DiagnoseCommand(AppsignalCLICommand):
 
     def _agent_information(self) -> None:
         print("Agent diagnostics")
-        print("  Extension tests")
-        print(f"    Configuration: {self.agent_report.configuration_valid()}")
-        if self.agent_report.configuration_error():
-            print(f"     Error: {self.agent_report.configuration_error()}")
         print("  Agent tests")
         print(f"    Started: {self.agent_report.started()}")
         print(f"    Process user id: {self.agent_report.user_id()}")
         print(f"    Process user group id: {self.agent_report.group_id()}")
         print(f"    Configuration: {self.agent_report.configuration_valid()}")
+        if self.agent_report.configuration_error():
+            print(f"        Error: {self.agent_report.configuration_error()}")
         print(f"    Logger: {self.agent_report.logger_started()}")
         print(
             f"    Working directory user id: {self.agent_report.working_directory_user_id()}"

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -89,11 +89,18 @@ class DiagnoseCommand(AppsignalCLICommand):
         )
 
     def run(self) -> int:
-        agent = Agent()
-        self.config = Config()
         self.send_report = self.args.send_report
         self.no_send_report = self.args.no_send_report
-        self.agent_report = AgentReport(json.loads(agent.diagnose()))
+
+        if self.send_report and self.no_send_report:
+            print("Error: Cannot use --send-report and --no-send-report together.")
+            return 1
+
+        agent = Agent()
+        agent_json = json.loads(agent.diagnose())
+        self.config = Config()
+        self.agent_report = AgentReport(agent_json)
+
         self.report = {
             "agent": {
                 "agent": {
@@ -158,8 +165,7 @@ class DiagnoseCommand(AppsignalCLICommand):
 
         if self.send_report or (not self.no_send_report and self._report_prompt()):
             self._send_diagnose_report()
-
-        if self.no_send_report:
+        elif self.no_send_report:
             print("Not sending report. (Specified with the --no-send-report option.)")
 
         return 0

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -70,12 +70,6 @@ class AgentReport:
         else:
             return "not writable"
 
-    def lock_path(self):
-        if self.report["lock_path"]["created"]["result"]:
-            return "writable"
-        else:
-            return "not writable"
-
 
 class DiagnoseCommand(AppsignalCLICommand):
     @staticmethod
@@ -255,12 +249,14 @@ class DiagnoseCommand(AppsignalCLICommand):
         if status == 200:
             token = response.json()["token"]
             print()
-            print(f'  Your support token: {token}')
-            print(f'  View this report:   https://appsignal.com/diagnose/{token}')
+            print(f"  Your support token: {token}")
+            print(f"  View this report:   https://appsignal.com/diagnose/{token}")
         else:
-            print("  Error: Something went wrong while submitting the report to AppSignal.")
-            print(f'  Response code: {status}')
-            print(f'  Response body: {response.text}')
+            print(
+                "  Error: Something went wrong while submitting the report to AppSignal."
+            )
+            print(f"  Response code: {status}")
+            print(f"  Response body: {response.text}")
 
     def _os_distribution(self):
         try:

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -20,10 +20,16 @@ class DiagnoseCommand(AppsignalCLICommand):
             action="store_true",
             help="Send the report to AppSignal",
         )
+        parser.add_argument(
+            "--no-send-report",
+            action="store_true",
+            help="Do not send the report to AppSignal",
+        )
 
     def run(self):
         self.config = Config()
         self.send_report = self.args.send_report
+        self.no_send_report = self.args.no_send_report
 
         self._header()
 
@@ -51,7 +57,7 @@ class DiagnoseCommand(AppsignalCLICommand):
         self._report_information()
         print()
 
-        if(self.send_report or self._report_prompt()):
+        if(self.send_report or (not self.no_send_report and self._report_prompt())):
             self._send_diagnose_report()
 
     def _header(self):

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -146,7 +146,9 @@ class DiagnoseCommand(AppsignalCLICommand):
         print()
 
         if self.send_report or (not self.no_send_report and self._report_prompt()):
-            self._send_diagnose_report()
+            token = self._send_diagnose_report()
+            print(f'  Your support token: {token}')
+            print(f'  View this report:   https://appsignal.com/diagnose/{token}')
 
         if self.no_send_report:
             print("Not sending report. (Specified with the --no-send-report option.)")
@@ -241,7 +243,8 @@ class DiagnoseCommand(AppsignalCLICommand):
         endpoint = self.config.option("diagnose_endpoint")
         url = f"{endpoint}?{params}"
 
-        requests.post(url, json={"diagnose": self.report})
+        response = requests.post(url, json={"diagnose": self.report})
+        return response.json()["token"]
 
     def _os_distribution(self):
         try:

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -374,7 +374,10 @@ class DiagnoseCommand(AppsignalCLICommand):
     def _os_distribution(self) -> str:
         try:
             return platform.freedesktop_os_release()["NAME"]
-        except OSError:
+        # The platform.freedesktop_os_release is not available in all Python
+        # versions that we support. That's why we catch AttributeError along with
+        # OSError which is thrown when the host OS doesn't comply with freedesktop.
+        except (OSError, AttributeError):
             return ""
 
     def _validate_push_api_key(self) -> str:

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -1,16 +1,14 @@
+import json
 import os
 import platform
 import urllib
 from argparse import ArgumentParser
-import requests
-import json
-
 from pathlib import Path
 
 import requests
 
-from appsignal.config import Config
 from appsignal.agent import Agent
+from appsignal.config import Config
 
 from ..__about__ import __version__
 from .command import AppsignalCLICommand
@@ -36,14 +34,14 @@ class DiagnoseCommand(AppsignalCLICommand):
         self.send_report = self.args.send_report
         self.no_send_report = self.args.no_send_report
         self.report = {
-                'agent': None,
-                'config': None,
-                'host': None,
-                'installation': None,
-                'library': {},
-                'paths': None,
-                'process': None,
-                'validation': None,
+            "agent": None,
+            "config": None,
+            "host": None,
+            "installation": None,
+            "library": {},
+            "paths": None,
+            "process": None,
+            "validation": None,
         }
         self.agent_report = json.loads(agent.diagnose())
 
@@ -73,7 +71,7 @@ class DiagnoseCommand(AppsignalCLICommand):
         self._report_information()
         print()
 
-        if(self.send_report or (not self.no_send_report and self._report_prompt())):
+        if self.send_report or (not self.no_send_report and self._report_prompt()):
             self._send_diagnose_report()
 
     def _header(self):
@@ -108,25 +106,25 @@ class DiagnoseCommand(AppsignalCLICommand):
         print("Agent diagnostics")
 
     def _configuration_information(self):
-        print(f"Configuration")
+        print("Configuration")
 
     def _validation_information(self):
-        print(f"Validation")
+        print("Validation")
 
     def _paths_information(self):
-        print(f"Paths")
+        print("Paths")
 
     def _report_information(self):
-        print(f"Diagnostics report")
+        print("Diagnostics report")
 
     def _report_prompt(self):
-      match input("  Send diagnostics report to AppSignal? (Y/n):"):
-        case "y" | "yes" | "":
-            return True
-        case "n" | "no" :
-            return False
-        case _:
-            report_prompt()
+        match input("  Send diagnostics report to AppSignal? (Y/n):"):
+            case "y" | "yes" | "":
+                return True
+            case "n" | "no":
+                return False
+            case _:
+                report_prompt()
 
     def _send_diagnose_report(self):
         params = urllib.parse.urlencode(
@@ -141,4 +139,4 @@ class DiagnoseCommand(AppsignalCLICommand):
         endpoint = self.config.option("diagnose_endpoint")
         url = f"{endpoint}?{params}"
 
-        response = requests.post(url, json={'diagnose': self.report})
+        requests.post(url, json={"diagnose": self.report})

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -40,19 +40,34 @@ class AgentReport:
         return self.report["host"]["gid"]["result"]
 
     def logger_started(self):
-        if self.report["logger"]["started"]["result"]:
+        if "logger" in self.report and self.report["logger"]["started"]["result"]:
             return "started"
         else:
             return "not started"
 
     def working_directory_user_id(self):
-        return self.report["working_directory_stat"]["uid"]["result"]
+        return (
+            "working_directory_stat" in self.report
+            and self.report["working_directory_stat"]["uid"]["result"]
+        )
 
     def working_directory_group_id(self):
-        return self.report["working_directory_stat"]["gid"]["result"]
+        return (
+            "working_directory_stat" in self.report
+            and self.report["working_directory_stat"]["gid"]["result"]
+        )
 
     def working_directory_permissions(self):
-        return self.report["working_directory_stat"]["mode"]["result"]
+        return (
+            "working_directory_stat" in self.report
+            and self.report["working_directory_stat"]["mode"]["result"]
+        )
+
+    def lock_path(self):
+        if "lock_path" in self.report and self.report["lock_path"]["created"]["result"]:
+            return "writable"
+        else:
+            return "not writable"
 
     def lock_path(self):
         if self.report["lock_path"]["created"]["result"]:
@@ -183,7 +198,7 @@ class DiagnoseCommand(AppsignalCLICommand):
         print("Configuration")
 
         for key in self.config.options:
-            print(f'  {key}: {repr(self.config.options[key])}')
+            print(f"  {key}: {repr(self.config.options[key])}")
 
         print()
         print("Read more about how the diagnose config output is rendered")

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -82,11 +82,11 @@ class DiagnoseCommand(AppsignalCLICommand):
             "agent": None,
             "config": None,
             "host": {
-                "architecture": platform.platform(),
+                "architecture": platform.machine(),
                 "heroku": os.environ.get("DYNO") is not None,
                 "language_version": platform.python_version(),
                 "os": platform.system().lower(),
-                "os_distribution": "",
+                "os_distribution": self._os_distribution(),
                 "root": False,
                 "running_in_container": self.config.option("running_in_container")
                 is not None,
@@ -103,6 +103,7 @@ class DiagnoseCommand(AppsignalCLICommand):
         }
 
         self._header()
+        print()
 
         self._library_information()
         print()
@@ -157,23 +158,23 @@ class DiagnoseCommand(AppsignalCLICommand):
     def _agent_information(self):
         print("Agent diagnostics")
         print("  Extension tests")
-        print(f"    Configuration: {self.agent_report.configuration_valid}")
+        print(f"    Configuration: {self.agent_report.configuration_valid()}")
         print("  Agent tests")
-        print(f"    Started: {self.agent_report.started}")
-        print(f"    Process user id: {self.agent_report.user_id}")
-        print(f"    Process user group id: {self.agent_report.group_id}")
-        print(f"    Configuration: {self.agent_report.configuration_valid}")
-        print(f"    Logger: {self.agent_report.logger_started}")
+        print(f"    Started: {self.agent_report.started()}")
+        print(f"    Process user id: {self.agent_report.user_id()}")
+        print(f"    Process user group id: {self.agent_report.group_id()}")
+        print(f"    Configuration: {self.agent_report.configuration_valid()}")
+        print(f"    Logger: {self.agent_report.logger_started()}")
         print(
-            f"    Working directory user id: {self.agent_report.working_directory_user_id}"
+            f"    Working directory user id: {self.agent_report.working_directory_user_id()}"
         )
         print(
-            f"    Working directory user group id: {self.agent_report.working_directory_group_id}"
+            f"    Working directory user group id: {self.agent_report.working_directory_group_id()}"
         )
         print(
-            f"    Working directory permissions: {self.agent_report.working_directory_permissions}"
+            f"    Working directory permissions: {self.agent_report.working_directory_permissions()}"
         )
-        print(f"    Lock path: {self.agent_report.lock_path}")
+        print(f"    Lock path: {self.agent_report.lock_path()}")
 
     def _configuration_information(self):
         print("Configuration")
@@ -210,3 +211,9 @@ class DiagnoseCommand(AppsignalCLICommand):
         url = f"{endpoint}?{params}"
 
         requests.post(url, json={"diagnose": self.report})
+
+    def _os_distribution(self):
+        try:
+            return platform.freedesktop_os_release()
+        except OSError:
+            return ""

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -182,6 +182,13 @@ class DiagnoseCommand(AppsignalCLICommand):
     def _configuration_information(self):
         print("Configuration")
 
+        for key in self.config.options:
+            print(f'  {key}: {repr(self.config.options[key])}')
+
+        print()
+        print("Read more about how the diagnose config output is rendered")
+        print("https://docs.appsignal.com/python/command-line/diagnose.html")
+
     def _validation_information(self):
         print("Validation")
 

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -89,11 +89,12 @@ class DiagnoseCommand(AppsignalCLICommand):
         print("=" * 80)
 
     def _library_information(self):
+        library_report = self.report["library"]
         print("AppSignal library")
         print("  Language: Python")
-        print(f'  Package version: "{__version__}"')
-        print(f'  Agent version: "91f1a7c"')
-        print(f"  Extension loaded: {self.agent_report['boot']['started']['result']}")
+        print(f'  Package version: "{library_report["package_version"]}"')
+        print(f'  Agent version: "{library_report["agent_version"]}"')
+        print(f'  Extension loaded: {library_report["extension_loaded"]}')
 
     def _installation_information(self):
         print("Extension installation report")

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -128,7 +128,7 @@ class DiagnoseCommand(AppsignalCLICommand):
             },
             "paths": self._paths_data(),
             "process": {
-                "pid": os.getpid(),
+                "uid": os.getuid(),
             },
             "validation": {"push_api_key": self._validate_push_api_key()},
         }

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -1,18 +1,22 @@
-import platform
 import os
-
+import platform
+from argparse import ArgumentParser
 from pathlib import Path
 
-from .command import AppsignalCLICommand
 from appsignal.config import Config
 
 from ..__about__ import __version__
+from .command import AppsignalCLICommand
+
 
 class DiagnoseCommand(AppsignalCLICommand):
-    def __init__(self):
-        self.config = Config()
+    @staticmethod
+    def init_parser(parser: ArgumentParser) -> None:
+        pass
 
     def run(self):
+        self.config = Config()
+
         self._header()
 
         self._library_information()

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -127,7 +127,9 @@ class DiagnoseCommand(AppsignalCLICommand):
                 "agent_version": "91f1a7c",
             },
             "paths": self._paths_data(),
-            "process": None,
+            "process": {
+                "pid": os.getpid(),
+            },
             "validation": {"push_api_key": self._validate_push_api_key()},
         }
 

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -73,8 +73,8 @@ class DiagnoseCommand(AppsignalCLICommand):
         print("AppSignal library")
         print("  Language: Python")
         print(f'  Package version: "{__version__}"')
-        print(f"  Agent version: ")
-        print(f"  Extension loaded: ")
+        print(f'  Agent version: "91f1a7c"')
+        print(f"  Extension loaded: true")
 
     def _installation_information(self):
         print("Extension installation report")

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -33,17 +33,22 @@ class DiagnoseCommand(AppsignalCLICommand):
         self.config = Config()
         self.send_report = self.args.send_report
         self.no_send_report = self.args.no_send_report
+        self.agent_report = json.loads(agent.diagnose())
         self.report = {
             "agent": None,
             "config": None,
             "host": None,
             "installation": None,
-            "library": {},
+            "library": {
+                "language": "python",
+                "package_version": __version__,
+                "agent_version": "91f1a7c",
+                "extension_loaded": self.agent_report["boot"]["started"]["result"],
+            },
             "paths": None,
             "process": None,
             "validation": None,
         }
-        self.agent_report = json.loads(agent.diagnose())
 
         self._header()
 

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -148,6 +148,9 @@ class DiagnoseCommand(AppsignalCLICommand):
         if self.send_report or (not self.no_send_report and self._report_prompt()):
             self._send_diagnose_report()
 
+        if self.no_send_report:
+            print("Not sending report. (Specified with the --no-send-report option.)")
+
     def _header(self):
         print("AppSignal diagnose")
         print("=" * 80)

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -266,16 +266,16 @@ class DiagnoseCommand(AppsignalCLICommand):
         print("  with your support token.")
         print()
 
-        match input("  Send diagnostics report to AppSignal? (Y/n):   "):
-            case "y" | "yes" | "":
-                print("Transmitting diagnostics report")
-                return True
-            case "n" | "no":
-                print("Not sending diagnostics information to AppSignal.")
-                return False
-            case _:
-                self._report_prompt()
-                return None
+        send_report = input("  Send diagnostics report to AppSignal? (Y/n):   ")
+
+        if send_report in ["y", "yes", ""]:
+            print("Transmitting diagnostics report")
+            return True
+        if send_report in ["n", "no"]:
+            print("Not sending diagnostics information to AppSignal.")
+            return False
+        self._report_prompt()
+        return None
 
     def _send_diagnose_report(self) -> None:
         params = urllib.parse.urlencode(
@@ -380,10 +380,10 @@ class DiagnoseCommand(AppsignalCLICommand):
             return ""
 
     def _validate_push_api_key(self) -> str:
-        match PushApiKeyValidator.validate(self.config):
-            case "valid":
-                return "valid"
-            case "invalid":
-                return "invalid"
-            case value:
-                return f"Failed to validate: {value}"
+        api_key_validation = PushApiKeyValidator.validate(self.config)
+
+        if api_key_validation == "valid":
+            return "valid"
+        if api_key_validation == "invalid":
+            return "invalid"
+        return f"Failed to validate: {api_key_validation}"

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -44,7 +44,8 @@ class DiagnoseCommand(AppsignalCLICommand):
                 "os": platform.system().lower(),
                 "os_distribution": "",
                 "root": False,
-                "running_in_container": self.config.option("running_in_container") is not None
+                "running_in_container": self.config.option("running_in_container")
+                is not None,
             },
             "library": {
                 "language": "python",
@@ -111,6 +112,36 @@ class DiagnoseCommand(AppsignalCLICommand):
 
     def _agent_information(self):
         print("Agent diagnostics")
+        print("  Extension tests")
+        print(
+            f'    Configuration: {"valid" if self.agent_report["config"]["valid"]["result"] else "invalid"}'
+        )
+        print("  Agent tests")
+        print(
+            f'    Started: {"started" if self.agent_report["boot"]["started"]["result"] else "not started"}'
+        )
+        print(f'    Process user id: {self.agent_report["host"]["uid"]["result"]}')
+        print(
+            f'    Process user group id: {self.agent_report["host"]["gid"]["result"]}'
+        )
+        print(
+            f'    Configuration: {"valid" if self.agent_report["config"]["valid"]["result"] else "invalid"}'
+        )
+        print(
+            f'    Logger: {"started" if self.agent_report["logger"]["started"]["result"] else "not started"}'
+        )
+        print(
+            f'    Working directory user id: {self.agent_report["working_directory_stat"]["uid"]["result"]}'
+        )
+        print(
+            f'    Working directory user group id: {self.agent_report["working_directory_stat"]["gid"]["result"]}'
+        )
+        print(
+            f'    Working directory permissions: {self.agent_report["working_directory_stat"]["mode"]["result"]}'
+        )
+        print(
+            f'    Lock path: {"writable" if self.agent_report["lock_path"]["created"]["result"] else "not writable"}'
+        )
 
     def _configuration_information(self):
         print("Configuration")

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -91,7 +91,18 @@ class DiagnoseCommand(AppsignalCLICommand):
         self.no_send_report = self.args.no_send_report
         self.agent_report = AgentReport(json.loads(agent.diagnose()))
         self.report = {
-            "agent": None,
+            "agent": {
+                "agent": {
+                    "boot": agent_json["boot"],
+                    "config": {
+                        "valid": agent_json["config"]["valid"],
+                    },
+                    "host": agent_json["host"],
+                    "lock_path": agent_json["lock_path"],
+                    "logger": agent_json["logger"],
+                    "working_directory_stat": agent_json["working_directory_stat"],
+                }
+            },
             "config": None,
             "host": {
                 "architecture": platform.machine(),

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -363,7 +363,7 @@ class DiagnoseCommand(AppsignalCLICommand):
                 return "file"
             if os.path.isdir(path):
                 return "directory"
-        return "Path does not exist"
+        return ""
 
     def _file_is_writable(self, path: str) -> bool:
         return os.access(path, os.W_OK)

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -125,4 +125,15 @@ class DiagnoseCommand(AppsignalCLICommand):
         endpoint = self.config.option("diagnose_endpoint")
         url = f"{endpoint}?{params}"
 
-        response = requests.post(url, json={})
+        response = requests.post(url, json={
+            'diagnose': {
+                'agent': None,
+                'config': None,
+                'host': None,
+                'installation': None,
+                'library': None,
+                'paths': None,
+                'process': None,
+                'validation': None,
+            }
+        })

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -22,7 +22,25 @@ class DiagnoseCommand(AppsignalCLICommand):
         self._library_information()
         print()
 
+        self._installation_information()
+        print()
+
         self._host_information()
+        print()
+
+        self._agent_information()
+        print()
+
+        self._configuration_information()
+        print()
+
+        self._validation_information()
+        print()
+
+        self._paths_information()
+        print()
+
+        self._report_information()
         print()
 
     def _header(self):
@@ -40,6 +58,9 @@ class DiagnoseCommand(AppsignalCLICommand):
         print(f"  Package version: {__version__}")
         print(f"  Agent version: ")
 
+    def _installation_information(self):
+        print("Extension installation report")
+
     def _host_information(self):
         print("Host information")
         print(f"  Architecture: {platform.platform()}")
@@ -48,3 +69,18 @@ class DiagnoseCommand(AppsignalCLICommand):
         print(f"  Root user: {os.getuid() == 0}")
         running_in_container = self.config.option("running_in_container")
         print(f"  Running in container: {running_in_container}")
+
+    def _agent_information(self):
+        print("Agent diagnostics")
+
+    def _configuration_information(self):
+      print(f"Configuration")
+
+    def _validation_information(self):
+      print(f"Validation")
+
+    def _paths_information(self):
+      print(f"Paths")
+
+    def _report_information(self):
+      print(f"Diagnostics report")

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -15,10 +15,15 @@ from .command import AppsignalCLICommand
 class DiagnoseCommand(AppsignalCLICommand):
     @staticmethod
     def init_parser(parser: ArgumentParser) -> None:
-        pass
+        parser.add_argument(
+            "--send-report",
+            action="store_true",
+            help="Send the report to AppSignal",
+        )
 
     def run(self):
         self.config = Config()
+        self.send_report = self.args.send_report
 
         self._header()
 

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -38,7 +38,6 @@ class DiagnoseCommand(AppsignalCLICommand):
             "agent": None,
             "config": None,
             "host": None,
-            "installation": None,
             "library": {
                 "language": "python",
                 "package_version": __version__,
@@ -53,9 +52,6 @@ class DiagnoseCommand(AppsignalCLICommand):
         self._header()
 
         self._library_information()
-        print()
-
-        self._installation_information()
         print()
 
         self._host_information()
@@ -95,9 +91,6 @@ class DiagnoseCommand(AppsignalCLICommand):
         print(f'  Package version: "{library_report["package_version"]}"')
         print(f'  Agent version: "{library_report["agent_version"]}"')
         print(f'  Extension loaded: {library_report["extension_loaded"]}')
-
-    def _installation_information(self):
-        print("Extension installation report")
 
     def _host_information(self):
         print("Host information")

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -1,7 +1,10 @@
 import os
 import platform
+import urllib
 from argparse import ArgumentParser
 from pathlib import Path
+
+import requests
 
 from appsignal.config import Config
 
@@ -43,6 +46,8 @@ class DiagnoseCommand(AppsignalCLICommand):
         self._report_information()
         print()
 
+        self._send_diagnose_report()
+
     def _header(self):
         print("AppSignal diagnose")
         print("=" * 80)
@@ -55,7 +60,7 @@ class DiagnoseCommand(AppsignalCLICommand):
     def _library_information(self):
         print("AppSignal library")
         print("  Language: Python")
-        print(f"  Package version: \"{__version__}\"")
+        print(f'  Package version: "{__version__}"')
         print(f"  Agent version: ")
         print(f"  Extension loaded: ")
 
@@ -75,13 +80,28 @@ class DiagnoseCommand(AppsignalCLICommand):
         print("Agent diagnostics")
 
     def _configuration_information(self):
-      print(f"Configuration")
+        print(f"Configuration")
 
     def _validation_information(self):
-      print(f"Validation")
+        print(f"Validation")
 
     def _paths_information(self):
-      print(f"Paths")
+        print(f"Paths")
 
     def _report_information(self):
-      print(f"Diagnostics report")
+        print(f"Diagnostics report")
+
+    def _send_diagnose_report(self):
+        params = urllib.parse.urlencode(
+            {
+                "api_key": self.config.option("push_api_key"),
+                "name": self.config.option("name"),
+                "environment": self.config.option("environment"),
+                "hostname": self.config.option("hostname") or "",
+            }
+        )
+
+        endpoint = self.config.option("diagnose_endpoint")
+        url = f"{endpoint}?{params}"
+
+        response = requests.post(url, json={})

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -43,8 +43,4 @@ class DiagnoseCommand(AppsignalCLICommand):
         print(f"  Python version: {platform.python_version()}")
         print(f"  Root user: {os.getuid() == 0}")
         running_in_container = self.config.option("running_in_container")
-        print(f"  Running in container: {running_in_container)}")
-
-    def _get_agent_version(self):
-
-
+        print(f"  Running in container: {running_in_container}")

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -316,7 +316,7 @@ class DiagnoseCommand(AppsignalCLICommand):
         return {
             "appsignal.log": {
                 "content": log_file_contents,
-                "exists": self._file_exists(log_file_path),
+                "exists": os.path.exists(log_file_path),
                 "mode": self._file_stat(log_file_path).get("mode"),
                 "ownership": self._file_stat(log_file_path).get("ownership"),
                 "path": log_file_path,
@@ -324,7 +324,7 @@ class DiagnoseCommand(AppsignalCLICommand):
                 "writable": self._file_is_writable(log_file_path),
             },
             "log_dir_path": {
-                "exists": self._file_exists(log_path),
+                "exists": os.path.exists(log_path),
                 "mode": self._file_stat(log_path).get("mode"),
                 "ownership": self._file_stat(log_path).get("ownership"),
                 "path": log_path,
@@ -332,7 +332,7 @@ class DiagnoseCommand(AppsignalCLICommand):
                 "writable": self._file_is_writable(log_path),
             },
             "working_dir": {
-                "exists": self._file_exists(working_dir),
+                "exists": os.path.exists(working_dir),
                 "mode": self._file_stat(working_dir).get("mode"),
                 "ownership": self._file_stat(working_dir).get("ownership"),
                 "path": working_dir,
@@ -340,9 +340,6 @@ class DiagnoseCommand(AppsignalCLICommand):
                 "writable": self._file_is_writable(working_dir),
             },
         }
-
-    def _file_exists(self, path: str) -> bool:
-        return os.path.isfile(path) or os.path.isdir(path)
 
     def _file_stat(self, path: str) -> dict:
         try:

--- a/src/appsignal/cli/install.py
+++ b/src/appsignal/cli/install.py
@@ -5,7 +5,6 @@ import os
 import requests
 
 from appsignal.config import Config
-from appsignal.push_api_key_validator import PushApiKeyValidator
 
 from .command import AppsignalCLICommand
 from .demo import DemoCommand

--- a/src/appsignal/cli/install.py
+++ b/src/appsignal/cli/install.py
@@ -4,6 +4,9 @@ import os
 
 import requests
 
+from appsignal.config import Config
+from appsignal.push_api_key_validator import PushApiKeyValidator
+
 from .command import AppsignalCLICommand
 from .demo import DemoCommand
 

--- a/src/appsignal/cli/install.py
+++ b/src/appsignal/cli/install.py
@@ -4,8 +4,6 @@ import os
 
 import requests
 
-from appsignal.config import Config
-
 from .command import AppsignalCLICommand
 from .demo import DemoCommand
 

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -26,7 +26,7 @@ class Options(TypedDict, total=False):
     app_path: str | None
     bind_address: str | None
     ca_file_path: str | None
-    diagnose_endpoint: Optional[str]
+    diagnose_endpoint: str | None
     disable_default_instrumentations: None | (
         list[Config.DefaultInstrumentation] | bool
     )

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -26,6 +26,7 @@ class Options(TypedDict, total=False):
     app_path: str | None
     bind_address: str | None
     ca_file_path: str | None
+    diagnose_endpoint: Optional[str]
     disable_default_instrumentations: None | (
         list[Config.DefaultInstrumentation] | bool
     )
@@ -72,6 +73,7 @@ class Config:
     )
     DEFAULT_CONFIG = Options(
         ca_file_path=CA_FILE_PATH,
+        diagnose_endpoint="https://appsignal.com/diag",
         enable_host_metrics=True,
         enable_nginx_metrics=False,
         enable_statsd=False,
@@ -135,6 +137,7 @@ class Config:
             active=parse_bool(os.environ.get("APPSIGNAL_ACTIVE")),
             bind_address=os.environ.get("APPSIGNAL_BIND_ADDRESS"),
             ca_file_path=os.environ.get("APPSIGNAL_CA_FILE_PATH"),
+            diagnose_endpoint=os.environ.get("APPSIGNAL_DIAGNOSE_ENDPOINT"),
             disable_default_instrumentations=parse_disable_default_instrumentations(
                 os.environ.get("APPSIGNAL_DISABLE_DEFAULT_INSTRUMENTATIONS")
             ),
@@ -199,6 +202,7 @@ class Config:
             "_APPSIGNAL_BIND_ADDRESS": options.get("bind_address"),
             "_APPSIGNAL_CA_FILE_PATH": options.get("ca_file_path"),
             "_APPSIGNAL_DNS_SERVERS": list_to_env_str(options.get("dns_servers")),
+            "_APPSIGNAL_DIAGNOSE_ENDPOINT": options.get("diagnose_endpoint"),
             "_APPSIGNAL_ENABLE_HOST_METRICS": bool_to_env_str(
                 options.get("enable_host_metrics")
             ),

--- a/src/appsignal/push_api_key_validator.py
+++ b/src/appsignal/push_api_key_validator.py
@@ -1,0 +1,22 @@
+import requests
+from appsignal.config import Config
+
+class PushApiKeyValidator:
+    @staticmethod
+    def validate(config: Config):
+        endpoint = config.option('endpoint')
+        url = f"{endpoint}/1/auth?api_key={config.option('push_api_key')}"
+        proxies = {}
+        if config.option("http_proxy"):
+            proxies["http"] = config.option("http_proxy")
+            proxies["https"] = config.option("http_proxy")
+
+        cert = config.option("ca_file_path")
+        response = requests.post(url, proxies=proxies, verify=cert)
+
+        if response.status_code == 200:
+            return 'valid'
+        elif response.status_code == 401:
+            return 'invalid'
+        else:
+            return response.status_code

--- a/src/appsignal/push_api_key_validator.py
+++ b/src/appsignal/push_api_key_validator.py
@@ -7,7 +7,7 @@ from appsignal.config import Config
 
 class PushApiKeyValidator:
     @staticmethod
-    def validate(config: Config):
+    def validate(config: Config) -> str:
         endpoint = config.option("endpoint")
         params = urllib.parse.urlencode(
             {
@@ -29,7 +29,6 @@ class PushApiKeyValidator:
 
         if response.status_code == 200:
             return "valid"
-        elif response.status_code == 401:
+        if response.status_code == 401:
             return "invalid"
-        else:
-            return response.status_code
+        return str(response.status_code)

--- a/src/appsignal/push_api_key_validator.py
+++ b/src/appsignal/push_api_key_validator.py
@@ -1,10 +1,12 @@
 import requests
+
 from appsignal.config import Config
+
 
 class PushApiKeyValidator:
     @staticmethod
     def validate(config: Config):
-        endpoint = config.option('endpoint')
+        endpoint = config.option("endpoint")
         url = f"{endpoint}/1/auth?api_key={config.option('push_api_key')}"
         proxies = {}
         if config.option("http_proxy"):
@@ -15,8 +17,8 @@ class PushApiKeyValidator:
         response = requests.post(url, proxies=proxies, verify=cert)
 
         if response.status_code == 200:
-            return 'valid'
+            return "valid"
         elif response.status_code == 401:
-            return 'invalid'
+            return "invalid"
         else:
             return response.status_code

--- a/src/appsignal/push_api_key_validator.py
+++ b/src/appsignal/push_api_key_validator.py
@@ -1,3 +1,5 @@
+import urllib
+
 import requests
 
 from appsignal.config import Config
@@ -7,7 +9,16 @@ class PushApiKeyValidator:
     @staticmethod
     def validate(config: Config):
         endpoint = config.option("endpoint")
-        url = f"{endpoint}/1/auth?api_key={config.option('push_api_key')}"
+        params = urllib.parse.urlencode(
+            {
+                "api_key": config.option("push_api_key"),
+                "name": config.option("name"),
+                "environment": config.option("environment"),
+                "hostname": config.option("hostname") or "",
+            }
+        )
+
+        url = f"{endpoint}/1/auth?{params}"
         proxies = {}
         if config.option("http_proxy"):
             proxies["http"] = config.option("http_proxy")

--- a/tests/test_push_api_key_validator.py
+++ b/tests/test_push_api_key_validator.py
@@ -1,0 +1,21 @@
+from appsignal.push_api_key_validator import PushApiKeyValidator
+from appsignal.config import Config, Options
+from unittest.mock import MagicMock
+
+def test_push_api_key_validator_valid(mocker):
+    mock_request = mocker.patch("requests.post")
+    mock_request.return_value = MagicMock(status_code=200)
+
+    assert PushApiKeyValidator.validate(Config(Options(push_api_key='valid'))) == 'valid'
+
+def test_push_api_key_validator_invalid(mocker):
+    mock_request = mocker.patch("requests.post")
+    mock_request.return_value = MagicMock(status_code=401)
+
+    assert PushApiKeyValidator.validate(Config(Options(push_api_key='invalid'))) == 'invalid'
+
+def test_push_api_key_validator_error(mocker):
+    mock_request = mocker.patch("requests.post")
+    mock_request.return_value = MagicMock(status_code=500)
+
+    assert PushApiKeyValidator.validate(Config(Options(push_api_key='500'))) == 500

--- a/tests/test_push_api_key_validator.py
+++ b/tests/test_push_api_key_validator.py
@@ -27,4 +27,4 @@ def test_push_api_key_validator_error(mocker):
     mock_request = mocker.patch("requests.post")
     mock_request.return_value = MagicMock(status_code=500)
 
-    assert PushApiKeyValidator.validate(Config(Options(push_api_key="500"))) == 500
+    assert PushApiKeyValidator.validate(Config(Options(push_api_key="500"))) == "500"

--- a/tests/test_push_api_key_validator.py
+++ b/tests/test_push_api_key_validator.py
@@ -1,21 +1,30 @@
-from appsignal.push_api_key_validator import PushApiKeyValidator
-from appsignal.config import Config, Options
 from unittest.mock import MagicMock
+
+from appsignal.config import Config, Options
+from appsignal.push_api_key_validator import PushApiKeyValidator
+
 
 def test_push_api_key_validator_valid(mocker):
     mock_request = mocker.patch("requests.post")
     mock_request.return_value = MagicMock(status_code=200)
 
-    assert PushApiKeyValidator.validate(Config(Options(push_api_key='valid'))) == 'valid'
+    assert (
+        PushApiKeyValidator.validate(Config(Options(push_api_key="valid"))) == "valid"
+    )
+
 
 def test_push_api_key_validator_invalid(mocker):
     mock_request = mocker.patch("requests.post")
     mock_request.return_value = MagicMock(status_code=401)
 
-    assert PushApiKeyValidator.validate(Config(Options(push_api_key='invalid'))) == 'invalid'
+    assert (
+        PushApiKeyValidator.validate(Config(Options(push_api_key="invalid")))
+        == "invalid"
+    )
+
 
 def test_push_api_key_validator_error(mocker):
     mock_request = mocker.patch("requests.post")
     mock_request.return_value = MagicMock(status_code=500)
 
-    assert PushApiKeyValidator.validate(Config(Options(push_api_key='500'))) == 500
+    assert PushApiKeyValidator.validate(Config(Options(push_api_key="500"))) == 500


### PR DESCRIPTION
This PR includes a diagnose command which can be called through `appsignal diagnose`, a report that can be submitted to AppSignal, and a report that's printed to the terminal. 

This also involves some shortcuts being made so we can work from a passing test suite. So far, the shortcuts made are a couple of hardcoded values, which will be fixed in this pull request, but are moved back for now. I'm listing them here so we're clear on what's not yet implemented, outside of the test failures:

# TODO

- [x] Add the `diagnose` command
- [x] Make diagnose tests pass -> https://github.com/appsignal/diagnose_tests/pull/92
- [x] Add diagnose tests to CI