### PR TITLE
Upgrade type annotations

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import platform

--- a/src/appsignal/__about__.py
+++ b/src/appsignal/__about__.py
@@ -1,1 +1,4 @@
+from __future__ import annotations
+
+
 __version__ = "0.1.4"

--- a/src/appsignal/cli/base.py
+++ b/src/appsignal/cli/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from docopt import docopt
 
 from ..__about__ import __version__

--- a/src/appsignal/cli/command.py
+++ b/src/appsignal/cli/command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Optional
 

--- a/src/appsignal/cli/command.py
+++ b/src/appsignal/cli/command.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional
 
 
 class AppsignalCLICommand(ABC):
@@ -9,8 +8,8 @@ class AppsignalCLICommand(ABC):
     def run(self) -> int:
         raise NotImplementedError
 
-    _push_api_key: Optional[str]
-    _name: Optional[str]
+    _push_api_key: str | None
+    _name: str | None
 
     def _input_push_api_key(self) -> None:
         key = input("Please enter your Push API key: ")

--- a/src/appsignal/cli/demo.py
+++ b/src/appsignal/cli/demo.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 

--- a/src/appsignal/cli/install.py
+++ b/src/appsignal/cli/install.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 import requests
@@ -103,7 +105,7 @@ class InstallCommand(AppsignalCLICommand):
                     return file
         return None
 
-    def _search_dependency(self, dependency_name):
+    def _search_dependency(self, dependency_name: str):
         requirement_file = self._requirements_file()
         if requirement_file:
             with open(requirement_file, "r") as f:
@@ -156,7 +158,7 @@ class InstallCommand(AppsignalCLICommand):
         print("You can check a list of the supported integrations here:")
         print("https://docs.appsignal.com/python/instrumentations")
 
-    def _add_dependency(self, dependency_name) -> None:
+    def _add_dependency(self, dependency_name: str) -> None:
         requirement_file = self._requirements_file()
         if requirement_file:
             with open(requirement_file, "a") as f:

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -3,16 +3,7 @@ from __future__ import annotations
 import os
 import platform
 import tempfile
-from typing import (
-    TYPE_CHECKING,
-    List,
-    Literal,
-    Optional,
-    TypedDict,
-    Union,
-    cast,
-    get_args,
-)
+from typing import TYPE_CHECKING, List, Literal, TypedDict, cast, get_args
 
 from .__about__ import __version__
 
@@ -22,38 +13,38 @@ if TYPE_CHECKING:
 
 
 class Options(TypedDict, total=False):
-    active: Optional[bool]
-    app_path: Optional[str]
-    ca_file_path: Optional[str]
-    disable_default_instrumentations: Optional[
-        Union[list[Config.DefaultInstrumentation], bool]
-    ]
-    dns_servers: Optional[list[str]]
-    enable_host_metrics: Optional[bool]
-    enable_nginx_metrics: Optional[bool]
-    enable_statsd: Optional[bool]
-    endpoint: Optional[str]
-    environment: Optional[str]
-    files_world_accessible: Optional[bool]
-    filter_parameters: Optional[list[str]]
-    filter_session_data: Optional[list[str]]
-    hostname: Optional[str]
-    http_proxy: Optional[str]
-    ignore_actions: Optional[list[str]]
-    ignore_errors: Optional[list[str]]
-    ignore_namespaces: Optional[list[str]]
-    log: Optional[str]
-    log_level: Optional[str]
-    log_path: Optional[str]
-    name: Optional[str]
-    push_api_key: Optional[str]
-    revision: Optional[str]
-    request_headers: Optional[list[str]]
-    running_in_container: Optional[bool]
-    send_environment_metadata: Optional[bool]
-    send_params: Optional[bool]
-    send_session_data: Optional[bool]
-    working_directory_path: Optional[str]
+    active: bool | None
+    app_path: str | None
+    ca_file_path: str | None
+    disable_default_instrumentations: None | (
+        list[Config.DefaultInstrumentation] | bool
+    )
+    dns_servers: list[str] | None
+    enable_host_metrics: bool | None
+    enable_nginx_metrics: bool | None
+    enable_statsd: bool | None
+    endpoint: str | None
+    environment: str | None
+    files_world_accessible: bool | None
+    filter_parameters: list[str] | None
+    filter_session_data: list[str] | None
+    hostname: str | None
+    http_proxy: str | None
+    ignore_actions: list[str] | None
+    ignore_errors: list[str] | None
+    ignore_namespaces: list[str] | None
+    log: str | None
+    log_level: str | None
+    log_path: str | None
+    name: str | None
+    push_api_key: str | None
+    revision: str | None
+    request_headers: list[str] | None
+    running_in_container: bool | None
+    send_environment_metadata: bool | None
+    send_params: bool | None
+    send_session_data: bool | None
+    working_directory_path: str | None
 
 
 class Sources(TypedDict):
@@ -107,7 +98,7 @@ class Config:
         List[DefaultInstrumentation], list(get_args(DefaultInstrumentation))
     )
 
-    def __init__(self, options: Optional[Options] = None) -> None:
+    def __init__(self, options: Options | None = None) -> None:
         self.sources = Sources(
             default=self.DEFAULT_CONFIG,
             system=Config.load_from_system(),
@@ -243,7 +234,7 @@ class Config:
             if value is not None:
                 os.environ[var] = str(value)
 
-    def log_file_path(self) -> Optional[str]:
+    def log_file_path(self) -> str | None:
         path = self.options.get("log_path")
 
         if path:
@@ -270,7 +261,7 @@ class Config:
         return os.path.join(path, "appsignal.log")
 
 
-def parse_bool(value: Optional[str]) -> Optional[bool]:
+def parse_bool(value: str | None) -> bool | None:
     if value is None:
         return None
 
@@ -283,7 +274,7 @@ def parse_bool(value: Optional[str]) -> Optional[bool]:
     return None
 
 
-def parse_list(value: Optional[str]) -> Optional[list[str]]:
+def parse_list(value: str | None) -> list[str] | None:
     if value is None:
         return None
 
@@ -291,8 +282,8 @@ def parse_list(value: Optional[str]) -> Optional[list[str]]:
 
 
 def parse_disable_default_instrumentations(
-    value: Optional[str],
-) -> Optional[Union[list[Config.DefaultInstrumentation], bool]]:
+    value: str | None,
+) -> list[Config.DefaultInstrumentation] | bool | None:
     if value is None:
         return None
 
@@ -307,14 +298,14 @@ def parse_disable_default_instrumentations(
     )
 
 
-def bool_to_env_str(value: Optional[bool]):
+def bool_to_env_str(value: bool | None):
     if value is None:
         return None
 
     return str(value).lower()
 
 
-def list_to_env_str(value: Optional[list[str]]):
+def list_to_env_str(value: list[str] | None):
     if value is None:
         return None
 

--- a/src/scripts/build_all.py
+++ b/src/scripts/build_all.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from runpy import run_path
 

--- a/src/scripts/build_hook.py
+++ b/src/scripts/build_hook.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 import os
 import shutil

--- a/src/scripts/build_hook.py
+++ b/src/scripts/build_hook.py
@@ -8,7 +8,7 @@ import subprocess
 import sysconfig
 import tarfile
 from runpy import run_path
-from typing import Any, Dict
+from typing import Any
 
 import requests
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
@@ -79,7 +79,7 @@ class DownloadError(Exception):
 
 
 class CustomBuildHook(BuildHookInterface):
-    def initialize(self, _version: str, build_data: Dict[str, Any]) -> None:
+    def initialize(self, _version: str, build_data: dict[str, Any]) -> None:
         """
         This occurs immediately before each build.
 

--- a/src/scripts/platform.py
+++ b/src/scripts/platform.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 TRIPLE_PLATFORM_TAG = {
     # MacOS builds
     "x86_64-darwin": "macosx_10_9_x86_64",

--- a/src/scripts/sdist_hook.py
+++ b/src/scripts/sdist_hook.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
 
 class CustomBuildHook(BuildHookInterface):
-    def initialize(self, version: str, build_data: Dict[str, Any]) -> None:
+    def initialize(self, version: str, build_data: dict[str, Any]) -> None:
         """
         This occurs immediately before each build.
 

--- a/src/scripts/sdist_hook.py
+++ b/src/scripts/sdist_hook.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Dict
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import builtins
 from contextlib import contextmanager
 from typing import cast

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 from logging import DEBUG, ERROR, INFO, WARNING

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from appsignal.__about__ import __version__

--- a/tests/test_opentelemetry.py
+++ b/tests/test_opentelemetry.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from typing import Dict
 from unittest.mock import Mock
 
 from appsignal.config import Config, Options
@@ -11,7 +10,7 @@ def raise_module_not_found_error():
     raise ModuleNotFoundError()
 
 
-def mock_adders() -> Dict[Config.DefaultInstrumentation, Mock]:
+def mock_adders() -> dict[Config.DefaultInstrumentation, Mock]:
     return {
         "opentelemetry.instrumentation.celery": Mock(),
         "opentelemetry.instrumentation.jinja2": Mock(

--- a/tests/test_opentelemetry.py
+++ b/tests/test_opentelemetry.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict
 from unittest.mock import Mock
 


### PR DESCRIPTION
1. Add `from __future__ import annotations` in every Python module. Doing so will make Python not evaluate type annotations at runtime.
2. Upgrade all type annotations. Since all type annotations are now lazy, we can use the latest syntax for them. So, instead of `Optional[List[Union[str, int]]]` we can write `list[str | int] | None`.