### PR TITLE
Refactoring: turn agent wrapper into a singleton

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,7 +5,7 @@ import tempfile
 
 import pytest
 
-from appsignal.agent import _reset_agent_active
+from appsignal.agent import agent
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -29,7 +29,7 @@ def remove_logging_handlers_after_tests():
 
 @pytest.fixture(scope="function", autouse=True)
 def reset_agent_active_state():
-    _reset_agent_active()
+    agent.active = False
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/src/appsignal/agent.py
+++ b/src/appsignal/agent.py
@@ -1,42 +1,32 @@
 from __future__ import annotations
 
-import os
 import subprocess
+from dataclasses import dataclass
+from pathlib import Path
 
 from .config import Config
 
 
-AGENT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "appsignal-agent")
-agent_active = False
+@dataclass
+class Agent:
+    path: Path = Path(__file__).parent / "appsignal-agent"
+    active: bool = False
+
+    def start(self, config: Config) -> None:
+        config.set_private_environ()
+        p = subprocess.Popen(
+            [self.path, "start", "--private"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        p.wait(timeout=1)
+        returncode = p.returncode
+        if returncode == 0:
+            self.active = True
+        else:
+            output, _ = p.communicate()
+            out = output.decode("utf-8")
+            print(f"AppSignal agent is unable to start ({returncode}): ", out)
 
 
-def is_agent_active():
-    global agent_active
-    return agent_active
-
-
-def _reset_agent_active() -> None:
-    global agent_active
-    agent_active = False
-
-
-def agent_is_active() -> None:
-    global agent_active
-    agent_active = True
-
-
-def start_agent(config: Config) -> None:
-    config.set_private_environ()
-    p = subprocess.Popen(
-        [AGENT_PATH, "start", "--private"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    p.wait(timeout=1)
-    returncode = p.returncode
-    if returncode == 0:
-        agent_is_active()
-    else:
-        output, _ = p.communicate()
-        out = output.decode("utf-8")
-        print(f"AppSignal agent is unable to start ({returncode}): ", out)
+agent = Agent()

--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -5,7 +5,7 @@ import sys
 from logging import DEBUG, ERROR, INFO, WARNING, Logger
 from typing import TYPE_CHECKING
 
-from .agent import start_agent
+from .agent import agent
 from .config import Config, Options
 from .opentelemetry import start_opentelemetry
 
@@ -30,7 +30,7 @@ class Client:
     def start(self) -> None:
         if self._config.option("active"):
             self._logger.info("Starting AppSignal")
-            start_agent(self._config)
+            agent.start(self._config)
             start_opentelemetry(self._config)
 
     def start_logger(self) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,7 @@ import os
 import re
 from logging import DEBUG, ERROR, INFO, WARNING
 
-from appsignal.agent import is_agent_active
+from appsignal.agent import agent
 from appsignal.client import Client
 
 
@@ -20,7 +20,7 @@ def test_client_agent_inactive():
     client.start()
 
     assert os.environ.get("_APPSIGNAL_ACTIVE") == "true"
-    assert is_agent_active() is False
+    assert agent.active is False
 
 
 def test_client_agent_active():
@@ -29,7 +29,7 @@ def test_client_agent_active():
     client.start()
 
     assert os.environ.get("_APPSIGNAL_ACTIVE") == "true"
-    assert is_agent_active() is True
+    assert agent.active is True
 
 
 def test_client_active():
@@ -53,7 +53,7 @@ def test_client_active():
         os.environ.get("OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST")
         == "accept,x-custom-header"
     )
-    assert is_agent_active()
+    assert agent.active
 
 
 def test_client_active_without_request_headers():


### PR DESCRIPTION
Before: agent state is a global variable
managed from a set of functions
using `global`.

After: the agent state is managed by
Agent singleton. The state is incapsulated,
and all related logic shares the same namespace.
The resulting code is shorter and easier to test.

I'd prefer to avoid a global state altogether
and let Client manage the Agent,
but that would require to rethink the tests
that currently implicitly manage
the agent state from autouse fixtures.