### PR TITLE
Update OpenTelemetry HTTP exporter path

### DIFF
--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -98,7 +98,7 @@ def start_opentelemetry(config: Config) -> None:
 
     provider = TracerProvider()
 
-    otlp_exporter = OTLPSpanExporter(endpoint="http://localhost:8099")
+    otlp_exporter = OTLPSpanExporter(endpoint="http://localhost:8099/v1/traces")
     exporter_processor = BatchSpanProcessor(otlp_exporter)
     provider.add_span_processor(exporter_processor)
     trace.set_tracer_provider(provider)


### PR DESCRIPTION
Specify the OpenTelemetry HTTP exporter should export to `/v1/traces` path so we can more easily differentiate different requests on the HTTP endpoint on the agent.

No agent changes are needed with this agent version, it listens to any and all paths (it ignores the path).

[skip changeset]