### PR TITLE
Restore literal typing for instrumentations

### DIFF
--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -80,7 +80,9 @@ def add_requests_instrumentation() -> None:
 
 DefaultInstrumentationAdder = Callable[[], None]
 
-DEFAULT_INSTRUMENTATION_ADDERS = {
+DEFAULT_INSTRUMENTATION_ADDERS: Mapping[
+    Config.DefaultInstrumentation, DefaultInstrumentationAdder
+] = {
     "opentelemetry.instrumentation.celery": add_celery_instrumentation,
     "opentelemetry.instrumentation.django": add_django_instrumentation,
     "opentelemetry.instrumentation.flask": add_flask_instrumentation,
@@ -111,7 +113,9 @@ def start_opentelemetry(config: Config) -> None:
 
 def add_instrumentations(
     config: Config,
-    _adders: Mapping[str, DefaultInstrumentationAdder] = DEFAULT_INSTRUMENTATION_ADDERS,
+    _adders: Mapping[
+        Config.DefaultInstrumentation, DefaultInstrumentationAdder
+    ] = DEFAULT_INSTRUMENTATION_ADDERS,
 ) -> None:
     logger = logging.getLogger("appsignal")
     disable_list = config.options.get("disable_default_instrumentations") or []

--- a/tests/test_opentelemetry.py
+++ b/tests/test_opentelemetry.py
@@ -10,7 +10,7 @@ def raise_module_not_found_error():
     raise ModuleNotFoundError()
 
 
-def mock_adders() -> dict[str, Mock]:
+def mock_adders() -> dict[Config.DefaultInstrumentation, Mock]:
     return {
         "opentelemetry.instrumentation.celery": Mock(),
         "opentelemetry.instrumentation.jinja2": Mock(


### PR DESCRIPTION
A nitpick on top of #95, restoring typing for the default instrumentation adders. Trying to prevent typos when referring to the default instrumentations (including our own typos!)

@orsinium I'm curious as to whether this makes sense to you, or am I too deep in the TypeScript mindset?

[skip changeset]