### PR TITLE
Migrate from docopt to argparse

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-sdk",
   "opentelemetry-exporter-otlp-proto-http",
-  "docopt",
 ]
 dynamic = ["version"]
 
@@ -81,7 +80,6 @@ dependencies = [
   "mypy>=1.0.0",
   "isort",
   "ruff>=0.0.243",
-  "docopt",
 
   "opentelemetry-api",
   "opentelemetry-sdk",
@@ -89,7 +87,6 @@ dependencies = [
 
   "hatchling",
   "types-deprecated",
-  "types-docopt",
   "types-requests",
   "django-stubs",
 ]

--- a/src/appsignal/__main__.py
+++ b/src/appsignal/__main__.py
@@ -1,0 +1,4 @@
+from .cli.base import run
+
+
+run()

--- a/src/appsignal/cli/base.py
+++ b/src/appsignal/cli/base.py
@@ -1,48 +1,45 @@
 from __future__ import annotations
 
-from typing import Any
+import sys
+from argparse import ArgumentParser
+from typing import Mapping, NoReturn
 
-from docopt import docopt
-
-from ..__about__ import __version__
 from .command import AppsignalCLICommand
 from .demo import DemoCommand
 from .install import InstallCommand
+from .version import VersionCommand
 
 
-DOC = """AppSignal for Python CLI.
-
-Usage:
-  appsignal install [--push-api-key=<key>]
-  appsignal demo [--application=<app>] [--push-api-key=<key>]
-  appsignal (-h | --help)
-  appsignal --version
-
-Options:
-  -h --help             Show this screen and exit.
-  --version             Show version number and exit.
-  --push-api-key=<key>  Push API Key to use for the installation and the demo.
-  --application=<app>   Application name to use for the demo.
-"""
+COMMANDS: Mapping[str, type[AppsignalCLICommand]] = {
+    "demo": DemoCommand,
+    "install": InstallCommand,
+    "version": VersionCommand,
+}
 
 
-def run() -> int:
+def run() -> NoReturn:
+    """The entry point for CLI."""
+    sys.exit(main(sys.argv[1:]))
+
+
+def main(argv: list[str]) -> int:
+    parser = ArgumentParser("appsignal", description="AppSignal for Python CLI.")
+    subparsers = parser.add_subparsers()
+    parser.set_defaults(cmd=None)
+
+    cmd_class: type[AppsignalCLICommand]
+    for name, cmd_class in COMMANDS.items():
+        subparser = subparsers.add_parser(name=name, help=cmd_class.__doc__)
+        subparser.set_defaults(cmd=cmd_class)
+        cmd_class.init_parser(subparser)
+    args = parser.parse_args(argv)
+
+    cmd_class = args.cmd
+    if cmd_class is None:
+        parser.print_help()
+        return 1
+    cmd = cmd_class(args=args)
     try:
-        version = f"AppSignal for Python v{__version__}"
-
-        arguments = docopt(DOC, version=version)
-
-        return command_for(arguments).run()
+        return cmd.run()
     except KeyboardInterrupt:
         return 0
-
-
-def command_for(arguments: dict[str, Any]) -> AppsignalCLICommand:
-    if arguments["install"]:
-        return InstallCommand(push_api_key=arguments["--push-api-key"])
-    if arguments["demo"]:
-        return DemoCommand(
-            push_api_key=arguments["--push-api-key"],
-            application=arguments["--application"],
-        )
-    raise NotImplementedError

--- a/src/appsignal/cli/base.py
+++ b/src/appsignal/cli/base.py
@@ -24,16 +24,9 @@ def run() -> NoReturn:
 
 def main(argv: list[str]) -> int:
     parser = ArgumentParser("appsignal", description="AppSignal for Python CLI.")
-    subparsers = parser.add_subparsers()
-    parser.set_defaults(cmd=None)
-
-    cmd_class: type[AppsignalCLICommand]
-    for name, cmd_class in COMMANDS.items():
-        subparser = subparsers.add_parser(name=name, help=cmd_class.__doc__)
-        subparser.set_defaults(cmd=cmd_class)
-        cmd_class.init_parser(subparser)
+    _register_commands(parser)
     args = parser.parse_args(argv)
-
+    cmd_class: type[AppsignalCLICommand] | None
     cmd_class = args.cmd
     if cmd_class is None:
         parser.print_help()
@@ -43,3 +36,13 @@ def main(argv: list[str]) -> int:
         return cmd.run()
     except KeyboardInterrupt:
         return 0
+
+
+def _register_commands(parser: ArgumentParser) -> None:
+    subparsers = parser.add_subparsers()
+    parser.set_defaults(cmd=None)
+    cmd_class: type[AppsignalCLICommand]
+    for name, cmd_class in COMMANDS.items():
+        subparser = subparsers.add_parser(name=name, help=cmd_class.__doc__)
+        subparser.set_defaults(cmd=cmd_class)
+        cmd_class.init_parser(subparser)

--- a/src/appsignal/cli/command.py
+++ b/src/appsignal/cli/command.py
@@ -1,23 +1,49 @@
 from __future__ import annotations
 
+import os
 from abc import ABC, abstractmethod
+from argparse import ArgumentParser, Namespace
+from dataclasses import dataclass
+from functools import cached_property
+
+from appsignal.config import Config
 
 
+@dataclass(frozen=True)
 class AppsignalCLICommand(ABC):
+    args: Namespace
+
+    @staticmethod
+    def init_parser(parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "--push-api-key",
+            default=os.environ.get("APPSIGNAL_PUSH_API_KEY"),
+            help="Push API Key",
+        )
+        parser.add_argument(
+            "--application",
+            default=os.environ.get("APPSIGNAL_APP_NAME"),
+            help="Application name",
+        )
+
     @abstractmethod
     def run(self) -> int:
         raise NotImplementedError
 
-    _push_api_key: str | None
-    _name: str | None
+    @cached_property
+    def _push_api_key(self) -> str | None:
+        key = self.args.push_api_key
+        while not key:
+            key = input("Please enter your Push API key: ")
+        return key
 
-    def _input_push_api_key(self) -> None:
-        key = input("Please enter your Push API key: ")
-        self._push_api_key = key
-        if self._push_api_key == "":
-            self._input_push_api_key()
+    @cached_property
+    def _name(self) -> str | None:
+        name = self.args.application
+        while not name:
+            name = input("Please enter the name of your application: ")
+        return name
 
-    def _input_name(self) -> None:
-        self._name = input("Please enter the name of your application: ")
-        if self._name == "":
-            self._input_name()
+    @cached_property
+    def _config(self) -> Config:
+        return Config()

--- a/src/appsignal/cli/demo.py
+++ b/src/appsignal/cli/demo.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 
 from opentelemetry import trace
 
@@ -11,19 +10,9 @@ from .command import AppsignalCLICommand
 
 
 class DemoCommand(AppsignalCLICommand):
-    def __init__(
-        self, push_api_key: str | None = None, application: str | None = None
-    ) -> None:
-        self._push_api_key = push_api_key or os.environ.get("APPSIGNAL_PUSH_API_KEY")
-        self._name = application or os.environ.get("APPSIGNAL_APP_NAME")
+    """Run demo application."""
 
     def run(self) -> int:
-        if self._push_api_key is None:
-            self._input_push_api_key()
-
-        if self._name is None:
-            self._input_name()
-
         print()
 
         client = Client(

--- a/src/appsignal/cli/install.py
+++ b/src/appsignal/cli/install.py
@@ -4,8 +4,6 @@ import os
 
 import requests
 
-from appsignal.config import Config
-
 from .command import AppsignalCLICommand
 from .demo import DemoCommand
 
@@ -23,22 +21,18 @@ INSTALL_FILE_NAME = "__appsignal__.py"
 
 
 class InstallCommand(AppsignalCLICommand):
-    def __init__(self, push_api_key: str | None = None) -> None:
-        self._push_api_key = push_api_key
-        self._name = None
-        self._config = Config()
+    """Generate Appsignal client integration code."""
 
     def run(self) -> int:
+        # Make sure to show input prompts before the welcome text.
+        self._name
+        self._push_api_key
+
         print("👋 Welcome to the AppSignal for Python installer!")
         print()
         print("Reach us at support@appsignal.com for support")
         print("Documentation available at https://docs.appsignal.com/python")
         print()
-
-        self._input_name()
-
-        if self._push_api_key is None:
-            self._input_push_api_key()
 
         print()
 
@@ -56,7 +50,10 @@ class InstallCommand(AppsignalCLICommand):
             self._write_file()
             print()
 
-            DemoCommand(push_api_key=self._push_api_key, application=self._name).run()
+            demo = DemoCommand(args=self.args)
+            demo._name = self._name
+            demo._push_api_key = self._push_api_key
+            demo.run()
 
             if self._search_dependency("django"):
                 self._django_installation()

--- a/src/appsignal/cli/install.py
+++ b/src/appsignal/cli/install.py
@@ -25,8 +25,8 @@ class InstallCommand(AppsignalCLICommand):
 
     def run(self) -> int:
         # Make sure to show input prompts before the welcome text.
-        self._name
-        self._push_api_key
+        self._name  # noqa: B018
+        self._push_api_key  # noqa: B018
 
         print("👋 Welcome to the AppSignal for Python installer!")
         print()

--- a/src/appsignal/cli/version.py
+++ b/src/appsignal/cli/version.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+from ..__about__ import __version__
+from .command import AppsignalCLICommand
+
+
+class VersionCommand(AppsignalCLICommand):
+    @staticmethod
+    def init_parser(parser: ArgumentParser) -> None:
+        pass
+
+    def run(self) -> int:
+        print(__version__)
+        return 0

--- a/src/appsignal/cli/version.py
+++ b/src/appsignal/cli/version.py
@@ -7,6 +7,8 @@ from .command import AppsignalCLICommand
 
 
 class VersionCommand(AppsignalCLICommand):
+    """Show the SDK version and exit."""
+
     @staticmethod
     def init_parser(parser: ArgumentParser) -> None:
         pass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -124,7 +124,9 @@ def test_install_command_when_file_exists_no_overwrite(mocker):
     ):
         main(["install"])
 
-    # assert [] == cast(MagicMock, builtins.open).mock_calls
+    from appsignal.cli import install
+
+    assert install.open.mock_calls == []  # type: ignore[attr-defined]
 
 
 def test_install_comand_when_api_key_is_not_valid(mocker):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import builtins
 from contextlib import contextmanager
-from typing import cast
 from unittest.mock import MagicMock
+
+from appsignal.cli.base import main
 
 
 EXPECTED_FILE_CONTENTS = """from appsignal import Appsignal
@@ -17,24 +17,23 @@ appsignal = Appsignal(
 
 
 @contextmanager
-def mock_input(mocker, pairs):
+def mock_input(mocker, *pairs: tuple[str, str]):
     prompt_calls = [mocker.call(prompt) for (prompt, _) in pairs]
     answers = [answer for (_, answer) in pairs]
-
-    mocker.patch("builtins.input", side_effect=answers)
-
+    mock = mocker.patch("builtins.input", side_effect=answers)
     yield
+    assert prompt_calls == mock.mock_calls
 
-    assert prompt_calls == cast(MagicMock, builtins.input).mock_calls
 
-
-def mock_file_operations(mocker, file_exists=False):
+def mock_file_operations(mocker, file_exists: bool = False):
     mocker.patch("os.path.exists", return_value=file_exists)
-    mocker.patch("builtins.open")
+    mocker.patch("appsignal.cli.install.open")
 
 
 def assert_wrote_file_contents(mocker):
-    builtins_open = cast(MagicMock, builtins.open)
+    from appsignal.cli import install
+
+    builtins_open: MagicMock = install.open  # type: ignore[attr-defined]
     assert mocker.call("__appsignal__.py", "w") in builtins_open.mock_calls
     assert (
         mocker.call().__enter__().write(EXPECTED_FILE_CONTENTS)
@@ -53,14 +52,10 @@ def test_install_command_run(mocker):
 
     with mock_input(
         mocker,
-        [
-            ("Please enter the name of your application: ", "My app name"),
-            ("Please enter your Push API key: ", "My push API key"),
-        ],
+        ("Please enter the name of your application: ", "My app name"),
+        ("Please enter your Push API key: ", "My push API key"),
     ):
-        from appsignal.cli.install import InstallCommand
-
-        InstallCommand().run()
+        main(["install"])
 
     assert_wrote_file_contents(mocker)
 
@@ -71,16 +66,12 @@ def test_install_command_when_empty_value_ask_again(mocker):
 
     with mock_input(
         mocker,
-        [
-            ("Please enter the name of your application: ", ""),
-            ("Please enter the name of your application: ", "My app name"),
-            ("Please enter your Push API key: ", ""),
-            ("Please enter your Push API key: ", "My push API key"),
-        ],
+        ("Please enter the name of your application: ", ""),
+        ("Please enter the name of your application: ", "My app name"),
+        ("Please enter your Push API key: ", ""),
+        ("Please enter your Push API key: ", "My push API key"),
     ):
-        from appsignal.cli.install import InstallCommand
-
-        InstallCommand().run()
+        main(["install"])
 
     assert_wrote_file_contents(mocker)
 
@@ -91,13 +82,9 @@ def test_install_command_when_push_api_key_given(mocker):
 
     with mock_input(
         mocker,
-        [
-            ("Please enter the name of your application: ", "My app name"),
-        ],
+        ("Please enter the name of your application: ", "My app name"),
     ):
-        from appsignal.cli.install import InstallCommand
-
-        InstallCommand(push_api_key="My push API key").run()
+        main(["install", "--push-api-key", "My push API key"])
 
     assert_wrote_file_contents(mocker)
 
@@ -108,19 +95,15 @@ def test_install_command_when_file_exists_overwrite(mocker):
 
     with mock_input(
         mocker,
-        [
-            ("Please enter the name of your application: ", "My app name"),
-            ("Please enter your Push API key: ", "My push API key"),
-            (
-                "The __appsignal__.py file already exists."
-                " Should it be overwritten? (y/N): ",
-                "y",
-            ),
-        ],
+        ("Please enter the name of your application: ", "My app name"),
+        ("Please enter your Push API key: ", "My push API key"),
+        (
+            "The __appsignal__.py file already exists."
+            " Should it be overwritten? (y/N): ",
+            "y",
+        ),
     ):
-        from appsignal.cli.install import InstallCommand
-
-        InstallCommand().run()
+        main(["install"])
 
     assert_wrote_file_contents(mocker)
 
@@ -131,21 +114,17 @@ def test_install_command_when_file_exists_no_overwrite(mocker):
 
     with mock_input(
         mocker,
-        [
-            ("Please enter the name of your application: ", "My app name"),
-            ("Please enter your Push API key: ", "My push API key"),
-            (
-                "The __appsignal__.py file already exists."
-                " Should it be overwritten? (y/N): ",
-                "n",
-            ),
-        ],
+        ("Please enter the name of your application: ", "My app name"),
+        ("Please enter your Push API key: ", "My push API key"),
+        (
+            "The __appsignal__.py file already exists."
+            " Should it be overwritten? (y/N): ",
+            "n",
+        ),
     ):
-        from appsignal.cli.install import InstallCommand
+        main(["install"])
 
-        InstallCommand().run()
-
-    assert [] == cast(MagicMock, builtins.open).mock_calls
+    # assert [] == cast(MagicMock, builtins.open).mock_calls
 
 
 def test_install_comand_when_api_key_is_not_valid(mocker):
@@ -153,10 +132,6 @@ def test_install_comand_when_api_key_is_not_valid(mocker):
 
     with mock_input(
         mocker,
-        [
-            ("Please enter the name of your application: ", "My app name"),
-        ],
+        ("Please enter the name of your application: ", "My app name"),
     ):
-        from appsignal.cli.install import InstallCommand
-
-        assert InstallCommand(push_api_key="bad-push-api-key").run() == 1
+        assert main(["install", "--push-api-key=bad-push-api-key"]) == 1


### PR DESCRIPTION
1. Remove docopt from dependencies.
1. Use argparse to configure CLI.
1. Use cached_property to ensure on type level that the API key and app name are always provided when we need them.

Before:

![image](https://github.com/appsignal/appsignal-python/assets/9638362/b435eb5e-ee51-4d73-8ff0-9e14fdc5529d)

After:

![image](https://github.com/appsignal/appsignal-python/assets/9638362/2c4c1444-2792-4658-941b-6107d2198a34)


TBH, I don't quite like that there are interactive prompts in the app. I'd remove them and make the CLI flags required. Then argparse will ask the user to provide these flags for us:

```
usage: appsignal demo [-h] --push-api-key PUSH_API_KEY --application APPLICATION
appsignal demo: error: the following arguments are required: --push-api-key, --application
```

Closes #84