### PR TITLE
Make mypy configuration more strict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,8 +151,13 @@ line_length = 88
 [tool.mypy]
 files = ["src", "tests"]
 check_untyped_defs = true
-show_error_codes = true
 disallow_untyped_defs = true
+no_implicit_optional = true
+show_error_codes = true
+strict_equality = true
+warn_redundant_casts = true
+warn_unreachable = true
+warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
 module = "opentelemetry.instrumentation.*"


### PR DESCRIPTION
Add some configuration options for mypy
making it more strict. I could add `strict = true` instead but that's too strict and some code
fails it. Maybe later.