### PR TITLE
Migrate from docopt to argparse take 5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-sdk",
   "opentelemetry-exporter-otlp-proto-http",
-  "docopt",
 ]
 dynamic = ["version"]
 
@@ -81,7 +80,6 @@ dependencies = [
   "mypy>=1.0.0",
   "isort",
   "ruff>=0.0.243",
-  "docopt",
 
   "opentelemetry-api",
   "opentelemetry-sdk",
@@ -89,7 +87,6 @@ dependencies = [
 
   "hatchling",
   "types-deprecated",
-  "types-docopt",
   "types-requests",
   "django-stubs",
 ]

--- a/src/appsignal/__main__.py
+++ b/src/appsignal/__main__.py
@@ -1,0 +1,4 @@
+from .cli.base import run
+
+
+run()

--- a/src/appsignal/cli/command.py
+++ b/src/appsignal/cli/command.py
@@ -1,23 +1,49 @@
 from __future__ import annotations
 
+import os
 from abc import ABC, abstractmethod
+from argparse import ArgumentParser, Namespace
+from dataclasses import dataclass
+from functools import cached_property
+
+from appsignal.config import Config
 
 
+@dataclass(frozen=True)
 class AppsignalCLICommand(ABC):
+    args: Namespace
+
+    @staticmethod
+    def init_parser(parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "--push-api-key",
+            default=os.environ.get("APPSIGNAL_PUSH_API_KEY"),
+            help="Push API Key",
+        )
+        parser.add_argument(
+            "--application",
+            default=os.environ.get("APPSIGNAL_APP_NAME"),
+            help="Application name",
+        )
+
     @abstractmethod
     def run(self) -> int:
         raise NotImplementedError
 
-    _push_api_key: str | None
-    _name: str | None
+    @cached_property
+    def _push_api_key(self) -> str | None:
+        key = self.args.push_api_key
+        while not key:
+            key = input("Please enter your Push API key: ")
+        return key
 
-    def _input_push_api_key(self) -> None:
-        key = input("Please enter your Push API key: ")
-        self._push_api_key = key
-        if self._push_api_key == "":
-            self._input_push_api_key()
+    @cached_property
+    def _name(self) -> str | None:
+        name = self.args.application
+        while not name:
+            name = input("Please enter the name of your application: ")
+        return name
 
-    def _input_name(self) -> None:
-        self._name = input("Please enter the name of your application: ")
-        if self._name == "":
-            self._input_name()
+    @cached_property
+    def _config(self) -> Config:
+        return Config()

--- a/src/appsignal/cli/demo.py
+++ b/src/appsignal/cli/demo.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 
 from opentelemetry import trace
 
@@ -11,19 +10,9 @@ from .command import AppsignalCLICommand
 
 
 class DemoCommand(AppsignalCLICommand):
-    def __init__(
-        self, push_api_key: str | None = None, application: str | None = None
-    ) -> None:
-        self._push_api_key = push_api_key or os.environ.get("APPSIGNAL_PUSH_API_KEY")
-        self._name = application or os.environ.get("APPSIGNAL_APP_NAME")
+    """Run demo application."""
 
     def run(self) -> int:
-        if self._push_api_key is None:
-            self._input_push_api_key()
-
-        if self._name is None:
-            self._input_name()
-
         print()
 
         client = Client(

--- a/src/appsignal/cli/install.py
+++ b/src/appsignal/cli/install.py
@@ -4,8 +4,6 @@ import os
 
 import requests
 
-from appsignal.config import Config
-
 from .command import AppsignalCLICommand
 from .demo import DemoCommand
 
@@ -23,22 +21,18 @@ INSTALL_FILE_NAME = "__appsignal__.py"
 
 
 class InstallCommand(AppsignalCLICommand):
-    def __init__(self, push_api_key: str | None = None) -> None:
-        self._push_api_key = push_api_key
-        self._name = None
-        self._config = Config()
+    """Generate Appsignal client integration code."""
 
     def run(self) -> int:
+        # Make sure to show input prompts before the welcome text.
+        self._name  # noqa: B018
+        self._push_api_key  # noqa: B018
+
         print("👋 Welcome to the AppSignal for Python installer!")
         print()
         print("Reach us at support@appsignal.com for support")
         print("Documentation available at https://docs.appsignal.com/python")
         print()
-
-        self._input_name()
-
-        if self._push_api_key is None:
-            self._input_push_api_key()
 
         print()
 
@@ -56,7 +50,10 @@ class InstallCommand(AppsignalCLICommand):
             self._write_file()
             print()
 
-            DemoCommand(push_api_key=self._push_api_key, application=self._name).run()
+            demo = DemoCommand(args=self.args)
+            demo._name = self._name
+            demo._push_api_key = self._push_api_key
+            demo.run()
 
             if self._search_dependency("django"):
                 self._django_installation()

--- a/src/appsignal/cli/version.py
+++ b/src/appsignal/cli/version.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+from ..__about__ import __version__
+from .command import AppsignalCLICommand
+
+
+class VersionCommand(AppsignalCLICommand):
+    """Show the SDK version and exit."""
+
+    @staticmethod
+    def init_parser(parser: ArgumentParser) -> None:
+        pass
+
+    def run(self) -> int:
+        print(__version__)
+        return 0


### PR DESCRIPTION
1. Remove docopt from dependencies.
1. Use argparse to configure CLI.
1. Use cached_property to ensure on type-level that the API key and app name are always provided when we need them.