### PR TITLE
Push api key validator

### DIFF
--- a/src/appsignal/cli/install.py
+++ b/src/appsignal/cli/install.py
@@ -8,6 +8,7 @@ from appsignal.config import Config
 
 from .command import AppsignalCLICommand
 from .demo import DemoCommand
+from .push_api_key_validator import PushApiKeyValidator
 
 
 INSTALL_FILE_TEMPLATE = """from appsignal import Appsignal
@@ -162,15 +163,5 @@ class InstallCommand(AppsignalCLICommand):
             with open(requirement_file, "a") as f:
                 f.write(f"{dependency_name}\n")
 
-    def _validate_push_api_key(self) -> bool:
-        endpoint = self._config.option("endpoint")
-        url = f"{endpoint}/1/auth?api_key={self._push_api_key}"
-        proxies = {}
-        if self._config.option("http_proxy"):
-            proxies["http"] = self._config.option("http_proxy")
-            proxies["https"] = self._config.option("http_proxy")
-
-        cert = self._config.option("ca_file_path")
-
-        response = requests.get(url, proxies=proxies, verify=cert)
-        return response.status_code == 200
+    def _validate_push_api_key(self):
+        return PushApiKeyValidator.validate(self._config) == "valid"

--- a/src/appsignal/cli/push_api_key_validator.py
+++ b/src/appsignal/cli/push_api_key_validator.py
@@ -1,11 +1,14 @@
 import urllib
+
 import requests
+
 from appsignal.config import Config
+
 
 class PushApiKeyValidator:
     @staticmethod
     def validate(config: Config):
-        endpoint = config.option('endpoint')
+        endpoint = config.option("endpoint")
         params = urllib.parse.urlencode(
             {
                 "api_key": config.option("push_api_key"),
@@ -25,8 +28,8 @@ class PushApiKeyValidator:
         response = requests.post(url, proxies=proxies, verify=cert)
 
         if response.status_code == 200:
-            return 'valid'
+            return "valid"
         elif response.status_code == 401:
-            return 'invalid'
+            return "invalid"
         else:
             return response.status_code

--- a/src/appsignal/push_api_key_validator.py
+++ b/src/appsignal/push_api_key_validator.py
@@ -1,0 +1,32 @@
+import urllib
+import requests
+from appsignal.config import Config
+
+class PushApiKeyValidator:
+    @staticmethod
+    def validate(config: Config):
+        endpoint = config.option('endpoint')
+        params = urllib.parse.urlencode(
+            {
+                "api_key": config.option("push_api_key"),
+                "name": config.option("name"),
+                "environment": config.option("environment"),
+                "hostname": config.option("hostname") or "",
+            }
+        )
+
+        url = f"{endpoint}/1/auth?{params}"
+        proxies = {}
+        if config.option("http_proxy"):
+            proxies["http"] = config.option("http_proxy")
+            proxies["https"] = config.option("http_proxy")
+
+        cert = config.option("ca_file_path")
+        response = requests.post(url, proxies=proxies, verify=cert)
+
+        if response.status_code == 200:
+            return 'valid'
+        elif response.status_code == 401:
+            return 'invalid'
+        else:
+            return response.status_code

--- a/tests/test_push_api_key_validator.py
+++ b/tests/test_push_api_key_validator.py
@@ -1,0 +1,21 @@
+from appsignal.push_api_key_validator import PushApiKeyValidator
+from appsignal.config import Config, Options
+from unittest.mock import MagicMock
+
+def test_push_api_key_validator_valid(mocker):
+    mock_request = mocker.patch("requests.post")
+    mock_request.return_value = MagicMock(status_code=200)
+
+    assert PushApiKeyValidator.validate(Config(Options(push_api_key='valid'))) == 'valid'
+
+def test_push_api_key_validator_invalid(mocker):
+    mock_request = mocker.patch("requests.post")
+    mock_request.return_value = MagicMock(status_code=401)
+
+    assert PushApiKeyValidator.validate(Config(Options(push_api_key='invalid'))) == 'invalid'
+
+def test_push_api_key_validator_error(mocker):
+    mock_request = mocker.patch("requests.post")
+    mock_request.return_value = MagicMock(status_code=500)
+
+    assert PushApiKeyValidator.validate(Config(Options(push_api_key='500'))) == 500

--- a/tests/test_push_api_key_validator.py
+++ b/tests/test_push_api_key_validator.py
@@ -1,21 +1,30 @@
-from appsignal.push_api_key_validator import PushApiKeyValidator
-from appsignal.config import Config, Options
 from unittest.mock import MagicMock
+
+from appsignal.cli.push_api_key_validator import PushApiKeyValidator
+from appsignal.config import Config, Options
+
 
 def test_push_api_key_validator_valid(mocker):
     mock_request = mocker.patch("requests.post")
     mock_request.return_value = MagicMock(status_code=200)
 
-    assert PushApiKeyValidator.validate(Config(Options(push_api_key='valid'))) == 'valid'
+    assert (
+        PushApiKeyValidator.validate(Config(Options(push_api_key="valid"))) == "valid"
+    )
+
 
 def test_push_api_key_validator_invalid(mocker):
     mock_request = mocker.patch("requests.post")
     mock_request.return_value = MagicMock(status_code=401)
 
-    assert PushApiKeyValidator.validate(Config(Options(push_api_key='invalid'))) == 'invalid'
+    assert (
+        PushApiKeyValidator.validate(Config(Options(push_api_key="invalid")))
+        == "invalid"
+    )
+
 
 def test_push_api_key_validator_error(mocker):
     mock_request = mocker.patch("requests.post")
     mock_request.return_value = MagicMock(status_code=500)
 
-    assert PushApiKeyValidator.validate(Config(Options(push_api_key='500'))) == 500
+    assert PushApiKeyValidator.validate(Config(Options(push_api_key="500"))) == 500


### PR DESCRIPTION
Currently, validating push API keys is done in the install command. The
upcoming diagnose command also needs to validate push API keys, so this
patch moves the code into a separate module that will be used from both
places.

[skip changeset]