### PR TITLE
Bump agent to 32590eb

### DIFF
--- a/.changesets/bump-agent-to-32590eb.md
+++ b/.changesets/bump-agent-to-32590eb.md
@@ -1,0 +1,8 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to 32590eb.
+
+- Only ignore disk metrics that start with "loop", not all mounted disks that end with a number to report metrics for more disks.

--- a/src/scripts/agent.py
+++ b/src/scripts/agent.py
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-    "version": "9e1ad6b",
+    "version": "32590eb",
     "mirrors": [
         "https://appsignal-agent-releases.global.ssl.fastly.net",
         "https://d135dj0rjqvssy.cloudfront.net",
@@ -12,131 +12,131 @@ APPSIGNAL_AGENT_CONFIG = {
     "triples": {
         "x86_64-darwin": {
             "static": {
-                "checksum": "dcbe4b05f84f56e376d99ce7febfa777a2d016670139af5dd7d62b2d8544fb53",
+                "checksum": "d19ddec878fd1c608bfc44219eee3059676e329575af0a0f9077a6ebd13ab759",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "02b28117b572ecaf85723603f7a8ef53155a364f484e9957d0a69a54cf1776b1",
+                "checksum": "068b99cc5b758e5657cdfe152e2c2ff6a7b53b5d1d14fb7b7f4aa2cb7eab37f3",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "universal-darwin": {
             "static": {
-                "checksum": "dcbe4b05f84f56e376d99ce7febfa777a2d016670139af5dd7d62b2d8544fb53",
+                "checksum": "d19ddec878fd1c608bfc44219eee3059676e329575af0a0f9077a6ebd13ab759",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "02b28117b572ecaf85723603f7a8ef53155a364f484e9957d0a69a54cf1776b1",
+                "checksum": "068b99cc5b758e5657cdfe152e2c2ff6a7b53b5d1d14fb7b7f4aa2cb7eab37f3",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-darwin": {
             "static": {
-                "checksum": "a015987b5b7df028ce38d9a00a637f13afd30ffd639f6487447f2319359a61aa",
+                "checksum": "ee637a448d7f063a603b34bff2a0387842fd9b7efe477f43c69850d1bde649d8",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "be0abdadd1f8fbee775339a007cde91e1a7a141dde335b65d67eb26ff088610c",
+                "checksum": "3c8f7f9c3ca53ca9c600290af1f033a96bff477ac8de236da23f5e3fd17643b2",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm64-darwin": {
             "static": {
-                "checksum": "a015987b5b7df028ce38d9a00a637f13afd30ffd639f6487447f2319359a61aa",
+                "checksum": "ee637a448d7f063a603b34bff2a0387842fd9b7efe477f43c69850d1bde649d8",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "be0abdadd1f8fbee775339a007cde91e1a7a141dde335b65d67eb26ff088610c",
+                "checksum": "3c8f7f9c3ca53ca9c600290af1f033a96bff477ac8de236da23f5e3fd17643b2",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm-darwin": {
             "static": {
-                "checksum": "a015987b5b7df028ce38d9a00a637f13afd30ffd639f6487447f2319359a61aa",
+                "checksum": "ee637a448d7f063a603b34bff2a0387842fd9b7efe477f43c69850d1bde649d8",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "be0abdadd1f8fbee775339a007cde91e1a7a141dde335b65d67eb26ff088610c",
+                "checksum": "3c8f7f9c3ca53ca9c600290af1f033a96bff477ac8de236da23f5e3fd17643b2",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux": {
             "static": {
-                "checksum": "aa27f9402c80bd5e241dce61f093eef291cde7c9866f724ac513f00c79ac00de",
+                "checksum": "c723895a2b627dc9bd6f756468206bb8b946e1ddaeab13f2562d47765bcbdc92",
                 "filename": "appsignal-aarch64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "6f948203ed2abfb320d99fe866c3fae81a41b2b9648ef121794fe33a08e89593",
+                "checksum": "a6d2bbd5659eb933274e47ebd1bddf5e124e641ddbf565aee2f46502bd77fdc9",
                 "filename": "appsignal-aarch64-linux-all-dynamic.tar.gz",
             },
         },
         "i686-linux": {
             "static": {
-                "checksum": "5de40c1cf697abcbbb875cdd02d28eef51453f8537d3cbb7abf17bc1dcc74403",
+                "checksum": "7e8e9b0ba5bde6ed3b3c697eb5c92c1840e0ab1a0ecad1e588d684c04f5aad2b",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "5afe58cdda2f19ecb1b7375cef4ca6d5a07d9a4cf3b0f4abb9a68202b44318a8",
+                "checksum": "65a47275eee9e75102398df2f8e6ba89ec1f47a3b017a9b97dffa314b76c4cd1",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86-linux": {
             "static": {
-                "checksum": "5de40c1cf697abcbbb875cdd02d28eef51453f8537d3cbb7abf17bc1dcc74403",
+                "checksum": "7e8e9b0ba5bde6ed3b3c697eb5c92c1840e0ab1a0ecad1e588d684c04f5aad2b",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "5afe58cdda2f19ecb1b7375cef4ca6d5a07d9a4cf3b0f4abb9a68202b44318a8",
+                "checksum": "65a47275eee9e75102398df2f8e6ba89ec1f47a3b017a9b97dffa314b76c4cd1",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux": {
             "static": {
-                "checksum": "754fa65f8539e77e2c548dff689a1d04c13306799eb79353a7821ef3d3cf1fb4",
+                "checksum": "b34f064d17a7ab047ebb0eac512452ed4ea91eb7035cd3caa5c06ec8c425ef8e",
                 "filename": "appsignal-x86_64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "4d1e9e79e4b7be253d60adc38e3146e61436f400f6934fb7ee9ee8d40ab93b1e",
+                "checksum": "7ae57a256a6a2115e5c36cab6d93d8c9ab63ffc9ff21f067b3e3769b4d847245",
                 "filename": "appsignal-x86_64-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux-musl": {
             "static": {
-                "checksum": "159fc5e3a9fdd01addabfc16f5c6b3e0e5c0ce2bf030b443fa739df9e987b656",
+                "checksum": "543e47617392cfc243aa053280cd98804ce71728ddd3e38c9b5c6f62a6006b97",
                 "filename": "appsignal-x86_64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "57749afa1a62d926208be4bacde2339f62f91e4dffcc84d8bd8777ebc26a44d8",
+                "checksum": "33ecdddcfb6eb9b895346355ab79d97b0c7258d19d9cdfe8d3ec0f384657bce5",
                 "filename": "appsignal-x86_64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux-musl": {
             "static": {
-                "checksum": "75469fd7d2b5da23be2b7763c171f76cef8f7aaafd9b2980a578348775949b52",
+                "checksum": "7e44a1e739f1d4e01fec73cdb4878c0b0b6af5b0f5b433f30807d768fd0cf2f0",
                 "filename": "appsignal-aarch64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "41ebceea27a4eadf3cdd2988ae3fe5025709d7c199e744917a894906bf0f48f9",
+                "checksum": "5319e91e5341e19b9ce58b93d439822c35511469a4a08e8e3b6afc75e95dd119",
                 "filename": "appsignal-aarch64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "x86_64-freebsd": {
             "static": {
-                "checksum": "5fe5c746800db955096713dbab5120d3e07d3c54a8801a9c55796ea4825f15ee",
+                "checksum": "5ddb4d0d357fbb4677156f538f325924fa53f7fbba5885761b58596fc2ded8ad",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "4fb6a9e7445f07f43863e9e3acd3859e4f70f8a084e10a94c6a39370cb22e478",
+                "checksum": "5a556a299d69b87c914dca1e0b19cfe1beb4b07ef003e88809600f309117c746",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },
         "amd64-freebsd": {
             "static": {
-                "checksum": "5fe5c746800db955096713dbab5120d3e07d3c54a8801a9c55796ea4825f15ee",
+                "checksum": "5ddb4d0d357fbb4677156f538f325924fa53f7fbba5885761b58596fc2ded8ad",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "4fb6a9e7445f07f43863e9e3acd3859e4f70f8a084e10a94c6a39370cb22e478",
+                "checksum": "5a556a299d69b87c914dca1e0b19cfe1beb4b07ef003e88809600f309117c746",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },


### PR DESCRIPTION
- Only ignore disk metrics that start with "loop", not all mounted disks that end with a number to report metrics for more disks.

[skip review]