### PR TITLE
Add bind_address config option for the agent

### DIFF
--- a/.changesets/allow-bind_address-configuration.md
+++ b/.changesets/allow-bind_address-configuration.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Allow configuration of the agent's TCP and UDP servers using the `bind_address` config option. This is by default set to `127.0.0.1`, which only makes it accessible from the same host. If you want it to be accessible from other machines, use `0.0.0.0` or a specific IP address.

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 class Options(TypedDict, total=False):
     active: bool | None
     app_path: str | None
+    bind_address: str | None
     ca_file_path: str | None
     disable_default_instrumentations: None | (
         list[Config.DefaultInstrumentation] | bool
@@ -132,6 +133,7 @@ class Config:
     def load_from_environment() -> Options:
         options = Options(
             active=parse_bool(os.environ.get("APPSIGNAL_ACTIVE")),
+            bind_address=os.environ.get("APPSIGNAL_BIND_ADDRESS"),
             ca_file_path=os.environ.get("APPSIGNAL_CA_FILE_PATH"),
             disable_default_instrumentations=parse_disable_default_instrumentations(
                 os.environ.get("APPSIGNAL_DISABLE_DEFAULT_INSTRUMENTATIONS")
@@ -194,6 +196,7 @@ class Config:
             "_APPSIGNAL_APP_ENV": options.get("environment"),
             "_APPSIGNAL_APP_NAME": options.get("name"),
             "_APPSIGNAL_APP_PATH": options.get("app_path"),
+            "_APPSIGNAL_BIND_ADDRESS": options.get("bind_address"),
             "_APPSIGNAL_CA_FILE_PATH": options.get("ca_file_path"),
             "_APPSIGNAL_DNS_SERVERS": list_to_env_str(options.get("dns_servers")),
             "_APPSIGNAL_ENABLE_HOST_METRICS": bool_to_env_str(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,6 +46,7 @@ def test_environ_source():
     os.environ["APPSIGNAL_ACTIVE"] = "true"
     os.environ["APPSIGNAL_APP_ENV"] = "development"
     os.environ["APPSIGNAL_APP_NAME"] = "MyApp"
+    os.environ["APPSIGNAL_BIND_ADDRESS"] = "0.0.0.0"
     os.environ["APPSIGNAL_CA_FILE_PATH"] = "/path/to/cacert.pem"
     os.environ["APPSIGNAL_DNS_SERVERS"] = "8.8.8.8,8.8.4.4"
     os.environ["APPSIGNAL_ENABLE_HOST_METRICS"] = "true"
@@ -75,6 +76,7 @@ def test_environ_source():
 
     env_options = Options(
         active=True,
+        bind_address="0.0.0.0",
         ca_file_path="/path/to/cacert.pem",
         dns_servers=["8.8.8.8", "8.8.4.4"],
         enable_host_metrics=True,
@@ -168,6 +170,7 @@ def test_set_private_environ():
         Options(
             active=True,
             app_path="/path/to/app",
+            bind_address="0.0.0.0",
             ca_file_path="/path/to/cacert.pem",
             dns_servers=["8.8.8.8", "8.8.4.4"],
             enable_host_metrics=True,
@@ -202,6 +205,7 @@ def test_set_private_environ():
     assert os.environ["_APPSIGNAL_APP_ENV"] == "development"
     assert os.environ["_APPSIGNAL_APP_NAME"] == "MyApp"
     assert os.environ["_APPSIGNAL_APP_PATH"] == "/path/to/app"
+    assert os.environ["_APPSIGNAL_BIND_ADDRESS"] == "0.0.0.0"
     assert os.environ["_APPSIGNAL_CA_FILE_PATH"] == "/path/to/cacert.pem"
     assert os.environ["_APPSIGNAL_DNS_SERVERS"] == "8.8.8.8,8.8.4.4"
     assert os.environ["_APPSIGNAL_ENABLE_HOST_METRICS"] == "true"


### PR DESCRIPTION
This feature has been available in the agent's standalone mode for a while now.

I'm cleaning up old issues and picking up this small one.

Part of https://github.com/appsignal/appsignal-agent/issues/915