### PR TITLE
Report total CPU usage host metric for VMs

### DIFF
--- a/.changesets/report-total-cpu-usage-metric-for-vms.md
+++ b/.changesets/report-total-cpu-usage-metric-for-vms.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Report total CPU usage host metric for VMs. This change adds another `state` tag value on the `cpu` metric called `total_usage`, which reports the VM's total CPU usage in percentages.

--- a/src/scripts/agent.py
+++ b/src/scripts/agent.py
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-    "version": "32590eb",
+    "version": "ceaca3b",
     "mirrors": [
         "https://appsignal-agent-releases.global.ssl.fastly.net",
         "https://d135dj0rjqvssy.cloudfront.net",
@@ -12,131 +12,131 @@ APPSIGNAL_AGENT_CONFIG = {
     "triples": {
         "x86_64-darwin": {
             "static": {
-                "checksum": "d19ddec878fd1c608bfc44219eee3059676e329575af0a0f9077a6ebd13ab759",
+                "checksum": "00f1b2c0b79827ce1abb751005221c4852787ca1804ebcd7e2634714d146ffe0",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "068b99cc5b758e5657cdfe152e2c2ff6a7b53b5d1d14fb7b7f4aa2cb7eab37f3",
+                "checksum": "9aed6c7268caf2b2fb33e8dc241f499089a68aaaab18c270a606a22c8afcad55",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "universal-darwin": {
             "static": {
-                "checksum": "d19ddec878fd1c608bfc44219eee3059676e329575af0a0f9077a6ebd13ab759",
+                "checksum": "00f1b2c0b79827ce1abb751005221c4852787ca1804ebcd7e2634714d146ffe0",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "068b99cc5b758e5657cdfe152e2c2ff6a7b53b5d1d14fb7b7f4aa2cb7eab37f3",
+                "checksum": "9aed6c7268caf2b2fb33e8dc241f499089a68aaaab18c270a606a22c8afcad55",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-darwin": {
             "static": {
-                "checksum": "ee637a448d7f063a603b34bff2a0387842fd9b7efe477f43c69850d1bde649d8",
+                "checksum": "e9195d0aa4e22214eeb2dcb54651014db09f2b84f5f5ef41f6c7fcddb9b58384",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "3c8f7f9c3ca53ca9c600290af1f033a96bff477ac8de236da23f5e3fd17643b2",
+                "checksum": "031c9ed8449f4ebb24ebb50861b76162f10c9f371f163d86a48a6bc695a1a4ba",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm64-darwin": {
             "static": {
-                "checksum": "ee637a448d7f063a603b34bff2a0387842fd9b7efe477f43c69850d1bde649d8",
+                "checksum": "e9195d0aa4e22214eeb2dcb54651014db09f2b84f5f5ef41f6c7fcddb9b58384",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "3c8f7f9c3ca53ca9c600290af1f033a96bff477ac8de236da23f5e3fd17643b2",
+                "checksum": "031c9ed8449f4ebb24ebb50861b76162f10c9f371f163d86a48a6bc695a1a4ba",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm-darwin": {
             "static": {
-                "checksum": "ee637a448d7f063a603b34bff2a0387842fd9b7efe477f43c69850d1bde649d8",
+                "checksum": "e9195d0aa4e22214eeb2dcb54651014db09f2b84f5f5ef41f6c7fcddb9b58384",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "3c8f7f9c3ca53ca9c600290af1f033a96bff477ac8de236da23f5e3fd17643b2",
+                "checksum": "031c9ed8449f4ebb24ebb50861b76162f10c9f371f163d86a48a6bc695a1a4ba",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux": {
             "static": {
-                "checksum": "c723895a2b627dc9bd6f756468206bb8b946e1ddaeab13f2562d47765bcbdc92",
+                "checksum": "d568c447595d5a46b726c09c44c66a28153bb85b843d9f915e755de60d2cc797",
                 "filename": "appsignal-aarch64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "a6d2bbd5659eb933274e47ebd1bddf5e124e641ddbf565aee2f46502bd77fdc9",
+                "checksum": "3884412af9f537b641113cb84e1b534e07289baadf5691cd3f4877fc4cd05896",
                 "filename": "appsignal-aarch64-linux-all-dynamic.tar.gz",
             },
         },
         "i686-linux": {
             "static": {
-                "checksum": "7e8e9b0ba5bde6ed3b3c697eb5c92c1840e0ab1a0ecad1e588d684c04f5aad2b",
+                "checksum": "4a8135e861ef8dd347ada22fa1fc993d1c5ba5db7f9f043a38fb9891c57368a5",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "65a47275eee9e75102398df2f8e6ba89ec1f47a3b017a9b97dffa314b76c4cd1",
+                "checksum": "baf3941d9913f8b348bb4fce01c7638f6e0a112a8cc788889b081f141949a643",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86-linux": {
             "static": {
-                "checksum": "7e8e9b0ba5bde6ed3b3c697eb5c92c1840e0ab1a0ecad1e588d684c04f5aad2b",
+                "checksum": "4a8135e861ef8dd347ada22fa1fc993d1c5ba5db7f9f043a38fb9891c57368a5",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "65a47275eee9e75102398df2f8e6ba89ec1f47a3b017a9b97dffa314b76c4cd1",
+                "checksum": "baf3941d9913f8b348bb4fce01c7638f6e0a112a8cc788889b081f141949a643",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux": {
             "static": {
-                "checksum": "b34f064d17a7ab047ebb0eac512452ed4ea91eb7035cd3caa5c06ec8c425ef8e",
+                "checksum": "4a22f454e5c125cd24436ad331d53df965394be81272c8ab366a2e6ea5f02625",
                 "filename": "appsignal-x86_64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "7ae57a256a6a2115e5c36cab6d93d8c9ab63ffc9ff21f067b3e3769b4d847245",
+                "checksum": "a49e8d8700b64f6aeb06c074cb628ed99d3d57662a52029f5409f8b51e185c4f",
                 "filename": "appsignal-x86_64-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux-musl": {
             "static": {
-                "checksum": "543e47617392cfc243aa053280cd98804ce71728ddd3e38c9b5c6f62a6006b97",
+                "checksum": "d770f78f9f87d3b5b01a93f0e3f0dffc36a4f8bd664ce37574fd0671276d4d8b",
                 "filename": "appsignal-x86_64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "33ecdddcfb6eb9b895346355ab79d97b0c7258d19d9cdfe8d3ec0f384657bce5",
+                "checksum": "1f018b072fca2234b7f8c9bdc0ae26a93826ddf3d715a1107c24b9e98a0e01d9",
                 "filename": "appsignal-x86_64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux-musl": {
             "static": {
-                "checksum": "7e44a1e739f1d4e01fec73cdb4878c0b0b6af5b0f5b433f30807d768fd0cf2f0",
+                "checksum": "ef4838e0cd3e43d0cc138e0eb6b78b7cf1f29244daa8379bb30c47b1497f5570",
                 "filename": "appsignal-aarch64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "5319e91e5341e19b9ce58b93d439822c35511469a4a08e8e3b6afc75e95dd119",
+                "checksum": "1bac2cce3dcde3e17174f56c7db149b69a347c0d40723c6555a292425fab41e0",
                 "filename": "appsignal-aarch64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "x86_64-freebsd": {
             "static": {
-                "checksum": "5ddb4d0d357fbb4677156f538f325924fa53f7fbba5885761b58596fc2ded8ad",
+                "checksum": "f1730afd98b48f3fa938fd07b27dc470e7dcd3f8d2e72a7a0fc2a4b080461f5b",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "5a556a299d69b87c914dca1e0b19cfe1beb4b07ef003e88809600f309117c746",
+                "checksum": "e7760c461ed4930983fe6b07a954c7ffa42c63ef627890c246eb2c4fb63bca84",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },
         "amd64-freebsd": {
             "static": {
-                "checksum": "5ddb4d0d357fbb4677156f538f325924fa53f7fbba5885761b58596fc2ded8ad",
+                "checksum": "f1730afd98b48f3fa938fd07b27dc470e7dcd3f8d2e72a7a0fc2a4b080461f5b",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "5a556a299d69b87c914dca1e0b19cfe1beb4b07ef003e88809600f309117c746",
+                "checksum": "e7760c461ed4930983fe6b07a954c7ffa42c63ef627890c246eb2c4fb63bca84",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },


### PR DESCRIPTION
This change adds another `state` tag value on the `cpu` metric called `total_usage`, which reports the VM's total CPU usage in percentages.

Part of https://github.com/appsignal/probes-rs/issues/64

[skip review]