### PR TITLE
Fix formatting for Python agent tests

### DIFF
--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -45,32 +45,33 @@ class AgentReport:
         return self.report["host"]["gid"]["result"]
 
     def logger_started(self) -> str:
-        if "logger" in self.report and self.report["logger"]["started"]["result"]:
-            return "started"
-        return "not started"
+        if "logger" in self.report:
+            if self.report["logger"]["started"]["result"]:
+                return "started"
+            return "not started"
+        return "-"
 
-    def working_directory_user_id(self) -> bool:
-        return (
-            "working_directory_stat" in self.report
-            and self.report["working_directory_stat"]["uid"]["result"]
-        )
+    def working_directory_user_id(self) -> str:
+        if "working_directory_stat" in self.report:
+            return self.report["working_directory_stat"]["uid"]["result"]
+        return "-"
 
-    def working_directory_group_id(self) -> bool:
-        return (
-            "working_directory_stat" in self.report
-            and self.report["working_directory_stat"]["gid"]["result"]
-        )
+    def working_directory_group_id(self) -> str:
+        if "working_directory_stat" in self.report:
+            return self.report["working_directory_stat"]["gid"]["result"]
+        return "-"
 
-    def working_directory_permissions(self) -> bool:
-        return (
-            "working_directory_stat" in self.report
-            and self.report["working_directory_stat"]["mode"]["result"]
-        )
+    def working_directory_permissions(self) -> str:
+        if "working_directory_stat" in self.report:
+            return self.report["working_directory_stat"]["mode"]["result"]
+        return "-"
 
     def lock_path(self) -> str:
-        if "lock_path" in self.report and self.report["lock_path"]["created"]["result"]:
-            return "writable"
-        return "not writable"
+        if "lock_path" in self.report:
+            if self.report["lock_path"]["created"]["result"]:
+                return "writable"
+            return "not writable"
+        return "-"
 
 
 class DiagnoseCommand(AppsignalCLICommand):


### PR DESCRIPTION
It would print things like `False`, `not started`, and `not writable` for tests that weren't present. This doesn't mean they are not writable, only that we couldn't test it. Most likely because the config wasn't loaded and it didn't know what paths to check.

Fix the format to match the other integrations and print a dash instead.

[skip changeset]