### PR TITLE
Warn about the package name change

### DIFF
--- a/src/appsignal/cli/base.py
+++ b/src/appsignal/cli/base.py
@@ -20,6 +20,14 @@ COMMANDS: Mapping[str, type[AppsignalCLICommand]] = {
 
 
 def run() -> NoReturn:
+    print(
+        "The AppSignal for Python integration is now published as the "
+        "`appsignal` package on PyPI. Update your project's dependencies "
+        "(e.g. requirements.txt) replacing the `appsignal-beta` package "
+        "with the `appsignal` package.",
+        file=sys.stderr,
+    )
+
     """The entry point for CLI."""
     sys.exit(main(sys.argv[1:]))
 

--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -27,6 +27,13 @@ class Client:
     }
 
     def __init__(self, **options: Unpack[Options]) -> None:
+        print(
+            "The AppSignal for Python integration is now published as the "
+            "`appsignal` package on PyPI. Update your project's dependencies "
+            "(e.g. requirements.txt) replacing the `appsignal-beta` package "
+            "with the `appsignal` package.",
+            file=sys.stderr,
+        )
         self._config = Config(options)
         self.start_logger()
 


### PR DESCRIPTION
Part of #111.

I'm opening this draft PR against the `main` branch, but this will be changed later to an `appsignal-beta` branch. That branch will be based on the first `appsignal` release, and it will be used for the last `appsignal-beta` release, being abandoned afterwards.

[skip changeset] (changeset will already be added by #112)

---

This commit will be added on a final release of the `appsignal-beta` package, informing users about the package name change to `appsignal` and prompting them to update their dependency requirements files.