### PR TITLE
Print deprecation warning if beta package present

### DIFF
--- a/.changesets/warn-if-appsignal-beta-package-is-present.md
+++ b/.changesets/warn-if-appsignal-beta-package-is-present.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Warn if the appsignal-beta package is present in the dependencies list to nudge people into switching to the new `appsignal` package.

--- a/src/appsignal/__init__.py
+++ b/src/appsignal/__init__.py
@@ -2,3 +2,10 @@ from .client import Client as Appsignal
 
 
 __all__ = ["Appsignal"]
+
+# Try and load the appsignal-beta package. If it's present and imported, it
+# will print a message about switching to the `appsignal` package.
+try:
+    import appsignal_beta  # type:ignore # noqa: F401
+except ImportError:
+    pass


### PR DESCRIPTION
We have renamed the package to `appsignal` in PR #112. Previously, we published the package as `appsignal-beta` because we couldn't publish using the `appsignal` package name.

To encourage people to switch to the `appsignal` package, we will ship a new version of the `appsignal-beta` package that has a dependency on the new `appsignal` package and prints a deprecation warning about the beta package if imported.

This change imports the beta package and prints the deprecation warning. If the package is not found, it will throw an error, which we'll catch and ignore.

Ignore the warnings from the linters about the library not being found.

Part of #111