### PR TITLE
Add the statsd_port config option

### DIFF
--- a/.changesets/add-statsd_port-config-option.md
+++ b/.changesets/add-statsd_port-config-option.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add the `statsd_port` config option to change the StatsD UDP server port of the appsignal-agent process. By default the port is set to 8125.

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -55,6 +55,7 @@ class Options(TypedDict, total=False):
     send_environment_metadata: bool | None
     send_params: bool | None
     send_session_data: bool | None
+    statsd_port: str | int | None
     working_directory_path: str | None
 
 
@@ -178,6 +179,7 @@ class Config:
             ),
             send_params=parse_bool(os.environ.get("APPSIGNAL_SEND_PARAMS")),
             send_session_data=parse_bool(os.environ.get("APPSIGNAL_SEND_SESSION_DATA")),
+            statsd_port=os.environ.get("APPSIGNAL_STATSD_PORT"),
             working_directory_path=os.environ.get("APPSIGNAL_WORKING_DIRECTORY_PATH"),
         )
 
@@ -241,6 +243,7 @@ class Config:
             "_APPSIGNAL_SEND_SESSION_DATA": bool_to_env_str(
                 options.get("send_session_data")
             ),
+            "_APPSIGNAL_STATSD_PORT": options.get("statsd_port"),
             "_APPSIGNAL_WORKING_DIRECTORY_PATH": options.get("working_directory_path"),
             "_APP_REVISION": options.get("revision"),
         }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -69,6 +69,7 @@ def test_environ_source():
     os.environ["APPSIGNAL_SEND_ENVIRONMENT_METADATA"] = "true"
     os.environ["APPSIGNAL_SEND_PARAMS"] = "true"
     os.environ["APPSIGNAL_SEND_SESSION_DATA"] = "true"
+    os.environ["APPSIGNAL_STATSD_PORT"] = "9001"
     os.environ["APPSIGNAL_WORKING_DIRECTORY_PATH"] = "/path/to/working/dir"
     os.environ["APP_REVISION"] = "abc123"
 
@@ -102,6 +103,7 @@ def test_environ_source():
         send_environment_metadata=True,
         send_params=True,
         send_session_data=True,
+        statsd_port="9001",
         working_directory_path="/path/to/working/dir",
     )
     assert config.sources["environment"] == env_options
@@ -195,6 +197,7 @@ def test_set_private_environ():
             send_environment_metadata=True,
             send_params=True,
             send_session_data=True,
+            statsd_port=9001,
             working_directory_path="/path/to/working/dir",
         )
     )
@@ -230,6 +233,7 @@ def test_set_private_environ():
     assert os.environ["_APPSIGNAL_SEND_ENVIRONMENT_METADATA"] == "true"
     assert os.environ["_APPSIGNAL_SEND_PARAMS"] == "true"
     assert os.environ["_APPSIGNAL_SEND_SESSION_DATA"] == "true"
+    assert os.environ["_APPSIGNAL_STATSD_PORT"] == "9001"
     assert os.environ["_APPSIGNAL_WORKING_DIRECTORY_PATH"] == "/path/to/working/dir"
     assert os.environ["_APP_REVISION"] == "abc123"
 
@@ -256,6 +260,14 @@ def test_set_private_environ_invalid_log_path():
     config.set_private_environ()
 
     assert os.environ["_APPSIGNAL_LOG_FILE_PATH"] == "/tmp/appsignal.log"
+
+
+def test_set_private_environ_str_is_none():
+    config = Config(Options(statsd_port=None))
+
+    config.set_private_environ()
+
+    assert os.environ.get("_APPSIGNAL_STATSD_PORT") is None
 
 
 def test_set_private_environ_bool_is_none():


### PR DESCRIPTION
Allow users to configure the statsd_port on the appsignal-agent process. This to fix two conflicting servers on the same port.

I had made this before (and checked Python off from the to do list), but never submitted the change 😖

Part of https://github.com/appsignal/appsignal-agent/issues/982