### PR TITLE
Add host_role config option

### DIFF
--- a/.changesets/add-role-config-option.md
+++ b/.changesets/add-role-config-option.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add the `role` config option. This config option can be set per host to generate some metrics automatically per host and possibly do things like grouping in the future.

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -40,6 +40,7 @@ class Options(TypedDict, total=False):
     filter_parameters: list[str] | None
     filter_session_data: list[str] | None
     hostname: str | None
+    host_role: str | None
     http_proxy: str | None
     ignore_actions: list[str] | None
     ignore_errors: list[str] | None
@@ -162,6 +163,7 @@ class Config:
                 os.environ.get("APPSIGNAL_FILTER_SESSION_DATA")
             ),
             hostname=os.environ.get("APPSIGNAL_HOSTNAME"),
+            host_role=os.environ.get("APPSIGNAL_HOST_ROLE"),
             http_proxy=os.environ.get("APPSIGNAL_HTTP_PROXY"),
             ignore_actions=parse_list(os.environ.get("APPSIGNAL_IGNORE_ACTIONS")),
             ignore_errors=parse_list(os.environ.get("APPSIGNAL_IGNORE_ERRORS")),
@@ -225,6 +227,7 @@ class Config:
                 options.get("filter_session_data")
             ),
             "_APPSIGNAL_HOSTNAME": options.get("hostname"),
+            "_APPSIGNAL_HOST_ROLE": options.get("host_role"),
             "_APPSIGNAL_HTTP_PROXY": options.get("http_proxy"),
             "_APPSIGNAL_IGNORE_ACTIONS": list_to_env_str(options.get("ignore_actions")),
             "_APPSIGNAL_IGNORE_ERRORS": list_to_env_str(options.get("ignore_errors")),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,6 +56,7 @@ def test_environ_source():
     os.environ["APPSIGNAL_FILTER_PARAMETERS"] = "password,secret"
     os.environ["APPSIGNAL_FILTER_SESSION_DATA"] = "key1,key2"
     os.environ["APPSIGNAL_HOSTNAME"] = "Test hostname"
+    os.environ["APPSIGNAL_HOST_ROLE"] = "a role"
     os.environ["APPSIGNAL_HTTP_PROXY"] = "http://proxy.local:9999"
     os.environ["APPSIGNAL_IGNORE_ACTIONS"] = "action1,action2"
     os.environ["APPSIGNAL_IGNORE_ERRORS"] = "error1,error2"
@@ -90,6 +91,7 @@ def test_environ_source():
         filter_parameters=["password", "secret"],
         filter_session_data=["key1", "key2"],
         hostname="Test hostname",
+        host_role="a role",
         http_proxy="http://proxy.local:9999",
         ignore_actions=["action1", "action2"],
         ignore_errors=["error1", "error2"],
@@ -186,6 +188,7 @@ def test_set_private_environ():
             filter_parameters=["password", "secret"],
             filter_session_data=["key1", "key2"],
             hostname="Test hostname",
+            host_role="a role",
             http_proxy="http://proxy.local:9999",
             ignore_actions=["action1", "action2"],
             ignore_errors=["error1", "error2"],
@@ -221,6 +224,7 @@ def test_set_private_environ():
     assert os.environ["_APPSIGNAL_FILTER_PARAMETERS"] == "password,secret"
     assert os.environ["_APPSIGNAL_FILTER_SESSION_DATA"] == "key1,key2"
     assert os.environ["_APPSIGNAL_HOSTNAME"] == "Test hostname"
+    assert os.environ["_APPSIGNAL_HOST_ROLE"] == "a role"
     assert os.environ["_APPSIGNAL_HTTP_PROXY"] == "http://proxy.local:9999"
     assert os.environ["_APPSIGNAL_IGNORE_ACTIONS"] == "action1,action2"
     assert os.environ["_APPSIGNAL_IGNORE_ERRORS"] == "error1,error2"
@@ -267,11 +271,12 @@ def test_set_private_environ_invalid_log_path():
 
 
 def test_set_private_environ_str_is_none():
-    config = Config(Options(statsd_port=None))
+    config = Config(Options(statsd_port=None, host_role=None))
 
     config.set_private_environ()
 
     assert os.environ.get("_APPSIGNAL_STATSD_PORT") is None
+    assert os.environ.get("_APPSIGNAL_HOST_ROLE") is None
 
 
 def test_set_private_environ_bool_is_none():


### PR DESCRIPTION
Allow users to configure a role for a host. It's not used a lot in the product yet, but we generate a metric for it and we can do some more stuff with it in the future.

I chose the `host_role` name because `role` alone is a bit ambiguous and the env var is named `APPSIGNAL_HOST_ROLE`.

Part of https://github.com/appsignal/appsignal-agent/issues/1020