### PR TITLE
Use relative imports in the CLI modules

### DIFF
--- a/.changesets/fix-cli-run-using-python--m-appsignal.md
+++ b/.changesets/fix-cli-run-using-python--m-appsignal.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix CLI using `python -m appsignal`. It would error with a `ModuleNotFoundError`.

--- a/src/appsignal/cli/command.py
+++ b/src/appsignal/cli/command.py
@@ -6,7 +6,7 @@ from argparse import ArgumentParser, Namespace
 from dataclasses import dataclass
 from functools import cached_property
 
-from appsignal.config import Config
+from ..config import Config
 
 
 @dataclass(frozen=True)

--- a/src/appsignal/cli/demo.py
+++ b/src/appsignal/cli/demo.py
@@ -4,8 +4,7 @@ import json
 
 from opentelemetry import trace
 
-from appsignal.client import Client
-
+from ..client import Client
 from .command import AppsignalCLICommand
 
 

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -11,11 +11,10 @@ from typing import Any
 
 import requests
 
-from appsignal.agent import Agent
-from appsignal.config import Config
-from appsignal.push_api_key_validator import PushApiKeyValidator
-
 from ..__about__ import __version__
+from ..agent import Agent
+from ..config import Config
+from ..push_api_key_validator import PushApiKeyValidator
 from .command import AppsignalCLICommand
 
 


### PR DESCRIPTION
When using `python -m appsignal ...` it would complain about missing imports.

Use relative imports instead, they seem to work for other imports, like `..__about__` in `src/appsignal/cli/version.py`.