### PR TITLE
Bump agent to 6133900

### DIFF
--- a/.changesets/bump-agent-to-6133900.md
+++ b/.changesets/bump-agent-to-6133900.md
@@ -1,0 +1,10 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to 6133900.
+
+- Fix `disk_inodes_usage` metric name format to not be interpreted as a JSON object.
+- Convert all OpenTelemetry sum metrics to AppSignal non-monotonic counters.
+- Rename standalone agent's `role` option to `host_role` so it's consistent with the integrations naming.

--- a/src/scripts/agent.py
+++ b/src/scripts/agent.py
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-    "version": "fac4694",
+    "version": "6133900",
     "mirrors": [
         "https://appsignal-agent-releases.global.ssl.fastly.net",
         "https://d135dj0rjqvssy.cloudfront.net",
@@ -12,131 +12,131 @@ APPSIGNAL_AGENT_CONFIG = {
     "triples": {
         "x86_64-darwin": {
             "static": {
-                "checksum": "2f4f60ffe27329522c5b24d2c6c289a9664fde6a518c1a7edafbecf342cf890d",
+                "checksum": "19cfea536fc6c4a8fe335a26d14ce955b422c23217902642f95d7df670152238",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "62b925bb35c155f2c847deb50fa1981d1066a616a476ef3e930eec7a00c7192c",
+                "checksum": "f5c4b66b45faac47473befdbe286a037d8fca9386339b00f59be9e9505d15b13",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "universal-darwin": {
             "static": {
-                "checksum": "2f4f60ffe27329522c5b24d2c6c289a9664fde6a518c1a7edafbecf342cf890d",
+                "checksum": "19cfea536fc6c4a8fe335a26d14ce955b422c23217902642f95d7df670152238",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "62b925bb35c155f2c847deb50fa1981d1066a616a476ef3e930eec7a00c7192c",
+                "checksum": "f5c4b66b45faac47473befdbe286a037d8fca9386339b00f59be9e9505d15b13",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-darwin": {
             "static": {
-                "checksum": "74d1d3c0ea914b42f2b53c44f0ed897fe2a1aa7d29f713a01e711e16068635b9",
+                "checksum": "4fa0dbccba79f70edc6844a86bfd047ccdd612d752b65aff46fe0e21d8a610ea",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "6a5d8284b95da299dd99d9332a887f664e41511cf0b67331e6ea3765fb6ea274",
+                "checksum": "f86e88647be6c64f0f1f56b1ac15e0e4453c7e4a6c997fd5e510cf459c572a57",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm64-darwin": {
             "static": {
-                "checksum": "74d1d3c0ea914b42f2b53c44f0ed897fe2a1aa7d29f713a01e711e16068635b9",
+                "checksum": "4fa0dbccba79f70edc6844a86bfd047ccdd612d752b65aff46fe0e21d8a610ea",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "6a5d8284b95da299dd99d9332a887f664e41511cf0b67331e6ea3765fb6ea274",
+                "checksum": "f86e88647be6c64f0f1f56b1ac15e0e4453c7e4a6c997fd5e510cf459c572a57",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm-darwin": {
             "static": {
-                "checksum": "74d1d3c0ea914b42f2b53c44f0ed897fe2a1aa7d29f713a01e711e16068635b9",
+                "checksum": "4fa0dbccba79f70edc6844a86bfd047ccdd612d752b65aff46fe0e21d8a610ea",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "6a5d8284b95da299dd99d9332a887f664e41511cf0b67331e6ea3765fb6ea274",
+                "checksum": "f86e88647be6c64f0f1f56b1ac15e0e4453c7e4a6c997fd5e510cf459c572a57",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux": {
             "static": {
-                "checksum": "43d4a3047b67f9d3e66a5f743fc20203602d0e936edce9596e8d777bb3716d22",
+                "checksum": "cdd75637940fcfd369b569e873048c7d37a3844d9d31d783e4459b375b78ee0e",
                 "filename": "appsignal-aarch64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "40ebc6e69315388273c1bdcad3726f7c470f029ee0b90881e9512152ba5b8992",
+                "checksum": "99b52c29d497d63f02a4ff7162152641b51e7ecd292d07f0330e7d4f3abc8075",
                 "filename": "appsignal-aarch64-linux-all-dynamic.tar.gz",
             },
         },
         "i686-linux": {
             "static": {
-                "checksum": "9885774dd31c202eab9af16b1ce3d9458f394efb54053957f3a3c13cce6c1f33",
+                "checksum": "a9374d1fd4baae84f1c4a74957cbb8c919b29ae2ab05a571ff75b9ca483717ab",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "9d6727c4eb0b6277d75558bf905bf7e3969b76aaf668505b96db966745ae1d5c",
+                "checksum": "d643c72add6fe1054faff034101cf5a2676a169c7bff479f3d79e71875598b8a",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86-linux": {
             "static": {
-                "checksum": "9885774dd31c202eab9af16b1ce3d9458f394efb54053957f3a3c13cce6c1f33",
+                "checksum": "a9374d1fd4baae84f1c4a74957cbb8c919b29ae2ab05a571ff75b9ca483717ab",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "9d6727c4eb0b6277d75558bf905bf7e3969b76aaf668505b96db966745ae1d5c",
+                "checksum": "d643c72add6fe1054faff034101cf5a2676a169c7bff479f3d79e71875598b8a",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux": {
             "static": {
-                "checksum": "477d5aad82b6087bb57622c4bff97d5bad4eef31b5af67ee0f75eab58e7a5412",
+                "checksum": "bd625ed84100d0632b298ac602b152463628c41afe56a8621745cdae626f8413",
                 "filename": "appsignal-x86_64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "291266080b89875a801bbf5bc0b6fe2a41ed8f583c44524bd2b83c64586ee9a6",
+                "checksum": "0daa644acfee46848282ad733b175e4994e7faf64c8bc046d2efff2b8fc1afdd",
                 "filename": "appsignal-x86_64-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux-musl": {
             "static": {
-                "checksum": "398660aea69b34c93e1f7db920e729a85ca0e92265dc47a9180e6d69078a2776",
+                "checksum": "7988c4a2a6ba5d59be2186ce9bf51ab50b6537a60888b08c8e9066172516e59d",
                 "filename": "appsignal-x86_64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "1b5fea7a0b8e6b94fb9d24ccf0bc54d0ad3b7e6f373e06b7c627cf0f0415ffc4",
+                "checksum": "93e47c9400ddae42a8cd2b80c09c9134ee96a76bf622c3ad5d53b776fec1a3f0",
                 "filename": "appsignal-x86_64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux-musl": {
             "static": {
-                "checksum": "6bf383560eae609f1e54f22a61d69ce067f9dae3b760ae7fbc8abbdfbf4e4585",
+                "checksum": "8e5fe2a8bc4cb7de4ba7d61fec48f15aa0cd580050f67752f07625853636eb16",
                 "filename": "appsignal-aarch64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "188fcede92cf1eb6dcddb4ffb22a1db7b95b5ff460f5784930a7a77cd37a903c",
+                "checksum": "01f993b3320f0377ef9f652bb215ce268da208f46a6f59ad0c0e71f57257b4ef",
                 "filename": "appsignal-aarch64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "x86_64-freebsd": {
             "static": {
-                "checksum": "4ccd4dbd30fe193944b5c578e7451e655b734954c203019ae975e44bef9e57fa",
+                "checksum": "09e21821eb98ad6afdb5d3708b67ea25799aedbee2ccb0d566b99d9c5703cb1e",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "882071dcae1dcd44f1a2624d111b6c4dc6a6c9d7f610412ad97bbed9c871f18b",
+                "checksum": "e77592de9dd7ff41efb6c1d2d88e06fa7b663e9ff009392bb971b1333e0f28d7",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },
         "amd64-freebsd": {
             "static": {
-                "checksum": "4ccd4dbd30fe193944b5c578e7451e655b734954c203019ae975e44bef9e57fa",
+                "checksum": "09e21821eb98ad6afdb5d3708b67ea25799aedbee2ccb0d566b99d9c5703cb1e",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "882071dcae1dcd44f1a2624d111b6c4dc6a6c9d7f610412ad97bbed9c871f18b",
+                "checksum": "e77592de9dd7ff41efb6c1d2d88e06fa7b663e9ff009392bb971b1333e0f28d7",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },


### PR DESCRIPTION
- Fix `disk_inodes_usage` metric name format to not be interpreted as a JSON object.
- Convert all OpenTelemetry sum metrics to AppSignal non-monotonic counters.

[skip review]