### PR TITLE
Add metric helpers for counters and gauges

### DIFF
--- a/.changesets/add-counter-metric-helper.md
+++ b/.changesets/add-counter-metric-helper.md
@@ -1,0 +1,20 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add helper for reporting counter metrics to AppSignal using OpenTelemetry. Use these helpers to simplify sending counter metrics as supported by AppSignal.
+
+```python
+from appsignal.metrics import increment_counter
+
+# Report a counter increasing
+increment_counter("counter_name", 1)
+# Report a counter decreasing
+increment_counter("counter_name", -1)
+
+# Add tags to counter
+increment_counter("counter_with_tags", 1, {"tag1": "value1"})
+```
+
+Consult our documentation for more information about AppSignal's [custom metrics](https://docs.appsignal.com/metrics/custom.html).

--- a/.changesets/add-gauge-metric-helper.md
+++ b/.changesets/add-gauge-metric-helper.md
@@ -1,0 +1,18 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add helper for reporting gauge metrics to AppSignal using OpenTelemetry. Use these helpers to simplify sending gauge metrics as supported by AppSignal.
+
+```python
+from appsignal.metrics import set_gauge
+
+# Report a gauge value
+set_gauge("gauge_name", 10)
+
+# Add tags to metrics
+set_gauge("gauge_with_tags", 10, {"tag1": "value1"})
+```
+
+Consult our documentation for more information about AppSignal's [custom metrics](https://docs.appsignal.com/metrics/custom.html).

--- a/src/appsignal/metrics.py
+++ b/src/appsignal/metrics.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+
+from opentelemetry.metrics import UpDownCounter, get_meter
+
+
+Tags = None | dict[str, str]
+
+_meter = get_meter("appsignal-helpers")
+_counters: dict[str, UpDownCounter] = {}
+
+
+def increment_counter(name: str, value: int | float, tags: Tags = None) -> None:
+    if name in _counters:
+        counter = _counters[name]
+    else:
+        counter = _meter.create_up_down_counter(name)
+        _counters[name] = counter
+
+    counter.add(value, tags)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,30 @@
+from opentelemetry.metrics import CallbackOptions, UpDownCounter
+
+from appsignal.metrics import _counters, increment_counter
+
+
+def test_increment_counter_creates_new_counter():
+    assert _counters.get("metric_name") is None
+
+    increment_counter("metric_name", 1)
+
+    assert isinstance(_counters["metric_name"], UpDownCounter)
+
+
+def test_increment_counter_creates_updates_existing_counter(mocker):
+    increment_counter("metric_name", 1)
+
+    counter_spy = mocker.spy(_counters["metric_name"], "add")
+    increment_counter("metric_name", 1)
+
+    counter_spy.assert_called_once_with(1, None)
+
+
+def test_increment_counter_with_tags(mocker):
+    increment_counter("metric_name", 1)
+
+    counter_spy = mocker.spy(_counters["metric_name"], "add")
+
+    increment_counter("metric_name", 1, {"tag1": "value1"})
+
+    counter_spy.assert_called_once_with(1, {"tag1": "value1"})

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
+from typing import Any
+
 from opentelemetry.metrics import CallbackOptions, UpDownCounter
 
-from appsignal.metrics import _counters, increment_counter
+from appsignal.metrics import _counters, _gauges, _meter, increment_counter, set_gauge
 
 
 def test_increment_counter_creates_new_counter():
@@ -11,7 +15,7 @@ def test_increment_counter_creates_new_counter():
     assert isinstance(_counters["metric_name"], UpDownCounter)
 
 
-def test_increment_counter_creates_updates_existing_counter(mocker):
+def test_increment_counter_updates_existing_counter(mocker):
     increment_counter("metric_name", 1)
 
     counter_spy = mocker.spy(_counters["metric_name"], "add")
@@ -28,3 +32,77 @@ def test_increment_counter_with_tags(mocker):
     increment_counter("metric_name", 1, {"tag1": "value1"})
 
     counter_spy.assert_called_once_with(1, {"tag1": "value1"})
+
+
+def test_set_gauge_creates_new_gauge(mocker):
+    meter_spy = mocker.spy(_meter, "create_observable_gauge")
+    assert "metric_name" not in _gauges
+
+    set_gauge("metric_name", 10)
+
+    # Registers the gauges internally
+    assert _gauges["metric_name"][None] == 10
+
+    # Check if it was registered on the meter
+    meter_spy.assert_called_once_with("metric_name", callbacks=mocker.ANY)
+    callbacks = meter_spy.call_args.kwargs["callbacks"]
+    assert len(callbacks) == 1
+
+    # Mock the ObservableGauge's async task calling the callbacks
+    return_values = callbacks[0](CallbackOptions())
+    assert len(return_values) == 1
+    return_value = return_values[0]
+    assert return_value.value == 10
+    assert return_value.attributes is None
+
+    # Resets gauge values
+    assert _gauges["metric_name"] == {}
+
+    return_values = callbacks[0](CallbackOptions())
+    assert len(return_values) == 0
+
+
+def test_set_gauge_updates_existing_gauge():
+    set_gauge("existing", 10)
+    set_gauge("existing", 11, None)  # None is also the default
+
+    assert _gauges["existing"][None] == 11
+
+    set_gauge("existing_with_tags", 10, {"tag1": "value1"})
+    set_gauge("existing_with_tags", 11, {"tag1": "value1"})
+
+    assert _gauges["existing_with_tags"][tags_key({"tag1": "value1"})] == 11
+
+
+def test_set_gauge_updates_with_tags(mocker):
+    meter_spy = mocker.spy(_meter, "create_observable_gauge")
+    set_gauge("with_tags1", 10, {"tag1": "value1"})
+    set_gauge("with_tags1", 11, {"tag1": "value1"})
+    set_gauge("with_tags1", 55, {"other": "value2"})
+
+    assert _gauges["with_tags1"][tags_key({"tag1": "value1"})] == 11
+    assert _gauges["with_tags1"][tags_key({"other": "value2"})] == 55
+
+    # Mock the ObservableGauge's async task calling the callbacks
+    callbacks = meter_spy.call_args.kwargs["callbacks"]
+    return_values = callbacks[0](CallbackOptions())
+    assert len(return_values) == 2
+
+    obs1 = return_values[0]
+    assert obs1.value == 11
+    assert obs1.attributes == {"tag1": "value1"}
+
+    obs2 = return_values[1]
+    assert obs2.value == 55
+    assert obs2.attributes == {"other": "value2"}
+
+    # Resets gauge values
+    assert _gauges["with_tags1"] == {}
+
+    callbacks = meter_spy.call_args.kwargs["callbacks"]
+    return_values = callbacks[0](CallbackOptions())
+    assert len(return_values) == 0
+
+
+def tags_key(tags: dict[str, str]) -> frozenset[Any]:
+    return frozenset(tags.items())


### PR DESCRIPTION
## Add counter helper for reporting counter metrics

Add convenience helper method to report counter metrics using the AppSignal terminology along with all the OpenTelemetry boilerplate.

This doesn't allow for setting units or metric descriptions, which OpenTelemetry supports, because we discard this metadata.

Part of #124

## Add gauge helper for reporting gauge metrics

Add convenience helper method to report gauge metrics using the AppSignal terminology along with all the OpenTelemetry boilerplate.

This doesn't allow for setting units or metric descriptions, which OpenTelemetry supports, because we discard this metadata.

This is using the OpenTelemetry ObservableGauge in the background, but exposes an API to what we're used to in other integrations with `set_gauge`.

The ObservableGauge registers a callback that it runs asynchronously in the background every 60 seconds. 60 seconds after the app starts it begins and when the app exits it's called one more time.

This makes the API simpler for our users so they don't have to worry about setting up methods for callbacks and such. It's more limiting, but people can always use the OpenTelemetry metrics module themselves to send metrics.

More information about the OpenTelemetry metrics SDK can be found here: https://opentelemetry-python.readthedocs.io/en/latest/sdk/metrics.html

Part of #124
