### PR TITLE
Export metric helpers in root module

### DIFF
--- a/.changesets/add-counter-metric-helper.md
+++ b/.changesets/add-counter-metric-helper.md
@@ -6,7 +6,7 @@ type: "add"
 Add helper for reporting counter metrics to AppSignal using OpenTelemetry. Use these helpers to simplify sending counter metrics as supported by AppSignal.
 
 ```python
-from appsignal.metrics import increment_counter
+from appsignal import increment_counter
 
 # Report a counter increasing
 increment_counter("counter_name", 1)

--- a/.changesets/add-gauge-metric-helper.md
+++ b/.changesets/add-gauge-metric-helper.md
@@ -6,7 +6,7 @@ type: "add"
 Add helper for reporting gauge metrics to AppSignal using OpenTelemetry. Use these helpers to simplify sending gauge metrics as supported by AppSignal.
 
 ```python
-from appsignal.metrics import set_gauge
+from appsignal import set_gauge
 
 # Report a gauge value
 set_gauge("gauge_name", 10)

--- a/src/appsignal/__init__.py
+++ b/src/appsignal/__init__.py
@@ -1,4 +1,5 @@
 from .client import Client as Appsignal
+from .metrics import increment_counter, set_gauge
 from .tracing import (
     send_error,
     send_error_with_context,
@@ -31,6 +32,8 @@ __all__ = [
     "set_error",
     "send_error",
     "send_error_with_context",
+    "increment_counter",
+    "set_gauge",
 ]
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -4,7 +4,8 @@ from typing import Any
 
 from opentelemetry.metrics import CallbackOptions, UpDownCounter
 
-from appsignal.metrics import _counters, _gauges, _meter, increment_counter, set_gauge
+from appsignal import increment_counter, set_gauge
+from appsignal.metrics import _counters, _gauges, _meter
 
 
 def test_increment_counter_creates_new_counter():


### PR DESCRIPTION
Like the tracing helpers, export the metrics helpers on the root so it doesn't have to be imported from `appsignal.metrics`.

[skip changeset] as it modifies an unreleased change.