### PR TITLE
Update tag value types to support int, float, bool

### DIFF
--- a/src/appsignal/metrics.py
+++ b/src/appsignal/metrics.py
@@ -6,7 +6,7 @@ from opentelemetry.metrics import CallbackOptions, Observation, UpDownCounter, g
 
 
 if TYPE_CHECKING:
-    Tags = dict[str, str] | None
+    Tags = dict[str, str | int | float | bool] | None
     TagsKey = frozenset[Any] | None
 
 _meter = get_meter("appsignal-helpers")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -30,9 +30,16 @@ def test_increment_counter_with_tags(mocker):
 
     counter_spy = mocker.spy(_counters["metric_name"], "add")
 
-    increment_counter("metric_name", 1, {"tag1": "value1"})
+    increment_counter(
+        "metric_name",
+        1,
+        {"tag1": "value1", "int": 123, "float": 123.456, "true": True, "false": False},
+    )
 
-    counter_spy.assert_called_once_with(1, {"tag1": "value1"})
+    counter_spy.assert_called_once_with(
+        1,
+        {"tag1": "value1", "int": 123, "float": 123.456, "true": True, "false": False},
+    )
 
 
 def test_set_gauge_creates_new_gauge(mocker):


### PR DESCRIPTION
We support these other types as tag values, so let's update the type definition to allow it.

[skip changeset] as it's an improvement on a not yet released feature.