### PR TITLE
Bump package classifiers to stable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   # Application version
-  "Development Status :: 3 - Alpha"
+  "Development Status :: 5 - Production/Stable"
 ]
 dependencies = [
   "opentelemetry-api",


### PR DESCRIPTION
pypi has a classifier to indicate which state of development a package is in. We're beyond alpha, and ready to be used in production apps. Let's classify as such.

[skip changeset] as it's a metadata change we don't need to release a new version for. It can be included in the next release.