### PR TITLE
Add demo CLI test and remove validate output

### DIFF
--- a/.changesets/validate-config-before-starting.md
+++ b/.changesets/validate-config-before-starting.md
@@ -3,4 +3,4 @@ bump: "patch"
 type: "fix"
 ---
 
-Validate the AppSignal configuration before starting the AppSignal agent. This prevents the agent from starting with an invalid config and while reporting no data. To avoid confusion, it will print an error about the invalid configuration upon start. The demo CLI will also more clearly communicate that it could not send any data in this invalid configuration scenario.
+Validate the AppSignal configuration before starting the AppSignal agent. This prevents the agent from starting with an invalid config and while reporting no data. The AppSignal client and demo CLI will communicate that they could not send any data in this invalid configuration scenario.

--- a/src/appsignal/cli/demo.py
+++ b/src/appsignal/cli/demo.py
@@ -20,6 +20,7 @@ class DemoCommand(AppsignalCLICommand):
         )
 
         if not client._config.is_active():
+            print("AppSignal not starting: no active config found.")
             return 1
 
         print("Sending example data to AppSignal...")

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -300,8 +300,6 @@ class Config:
         push_api_key = self.option("push_api_key") or ""
         if len(push_api_key.strip()) > 0:
             self.valid = True
-        else:
-            print("appsignal: Push API key not set after loading config. Not starting.")
 
 
 def parse_bool(value: str | None) -> bool | None:

--- a/tests/cli/test_demo.py
+++ b/tests/cli/test_demo.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from appsignal.cli.base import main
+
+
+@contextmanager
+def mock_input(mocker, *pairs: tuple[str, str]):
+    prompt_calls = [mocker.call(prompt) for (prompt, _) in pairs]
+    answers = [answer for (_, answer) in pairs]
+    mock = mocker.patch("builtins.input", side_effect=answers)
+    yield
+    assert prompt_calls == mock.mock_calls
+
+
+def test_demo_with_valid_config(mocker, capfd):
+    with mock_input(
+        mocker,
+        ("Please enter the name of your application: ", "My app name"),
+        ("Please enter your Push API key: ", "000"),
+    ):
+        assert main(["demo"]) == 0  # Successful run
+
+    out, err = capfd.readouterr()
+    assert out.find("Sending example data to AppSignal...") > 0
+
+
+def test_demo_with_invalid_config(mocker, capfd):
+    with mock_input(
+        mocker,
+        ("Please enter the name of your application: ", "My app name"),
+        ("Please enter your Push API key: ", " "),  # Invalid empty key
+    ):
+        assert main(["demo"]) == 1  # Exit with error
+
+    out, err = capfd.readouterr()
+    assert out.strip() == "AppSignal not starting: no active config found."

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -303,14 +303,9 @@ def test_is_active_valid_push_api_key():
     assert config.is_active() is True
 
 
-def test_is_active_invalid_push_api_key(capfd):
+def test_is_active_invalid_push_api_key():
     config = Config(Options(active=True, push_api_key=None))
     assert config.is_active() is False
-
-    out, err = capfd.readouterr()
-    assert (
-        out == "appsignal: Push API key not set after loading config. Not starting.\n"
-    )
 
     config = Config(Options(active=True, push_api_key=""))
     assert config.is_active() is False


### PR DESCRIPTION
Add the missing test for the demo CLI. It only tests if the config is valid or not, as testing if the OpenTelemetry span creation works is not necessary I think for now. It will require a lot of mocking, which doesn't tell us if the code actually still works or not.

I've also updated the config validation to not print an error immediately on validation. This may also be printed in some scenarios we don't want.

Preferably this is logged to the `appsignal.log` file like in the Ruby integration, but here we don't have a logger instance yet in the Python package. Something to improve later.

The demo CLI will log that the config is invalid, which can be debugged with the diagnose CLI if needed. The normal client start already logged a message when it couldn't start.

Needed for #138