### PR TITLE
Add demo CLI --environment option

### DIFF
--- a/.changesets/add---environment-cli-option-to-demo-cli-tool.md
+++ b/.changesets/add---environment-cli-option-to-demo-cli-tool.md
@@ -1,0 +1,10 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add the `--environment` CLI option to the demo CLI tool. This allow you to configure to which app environment the demo samples should be sent. It would default to production (and only be configurable via the `APPSIGNAL_APP_ENV` environment variable), but now it's configurable through the CLI options as well.
+
+```
+python -m appsignal demo --environment=production
+```

--- a/src/appsignal/cli/command.py
+++ b/src/appsignal/cli/command.py
@@ -14,12 +14,20 @@ class AppsignalCLICommand(ABC):
     args: Namespace
 
     @staticmethod
+    @abstractmethod
     def init_parser(parser: ArgumentParser) -> None:
+        pass
+
+    @staticmethod
+    def _push_api_key_argument(parser: ArgumentParser) -> None:
         parser.add_argument(
             "--push-api-key",
             default=os.environ.get("APPSIGNAL_PUSH_API_KEY"),
             help="Push API Key",
         )
+
+    @staticmethod
+    def _application_argument(parser: ArgumentParser) -> None:
         parser.add_argument(
             "--application",
             default=os.environ.get("APPSIGNAL_APP_NAME"),

--- a/src/appsignal/cli/command.py
+++ b/src/appsignal/cli/command.py
@@ -34,6 +34,14 @@ class AppsignalCLICommand(ABC):
             help="Application name",
         )
 
+    @staticmethod
+    def _environment_argument(parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "--environment",
+            default=os.environ.get("APPSIGNAL_APP_ENV"),
+            help="App environment",
+        )
+
     @abstractmethod
     def run(self) -> int:
         raise NotImplementedError
@@ -51,6 +59,15 @@ class AppsignalCLICommand(ABC):
         while not name:
             name = input("Please enter the name of your application: ")
         return name
+
+    @cached_property
+    def _environment(self) -> str | None:
+        environment = self.args.environment
+        while not environment:
+            environment = input(
+                "Please enter the application environment (development/production): "
+            )
+        return environment
 
     @cached_property
     def _config(self) -> Config:

--- a/src/appsignal/cli/demo.py
+++ b/src/appsignal/cli/demo.py
@@ -11,7 +11,6 @@ class DemoCommand(AppsignalCLICommand):
     """Run demo application."""
 
     def run(self) -> int:
-        print()
 
         client = Client(
             active=True,

--- a/src/appsignal/cli/demo.py
+++ b/src/appsignal/cli/demo.py
@@ -15,15 +15,18 @@ class DemoCommand(AppsignalCLICommand):
     @staticmethod
     def init_parser(parser: ArgumentParser) -> None:
         AppsignalCLICommand._application_argument(parser)
+        AppsignalCLICommand._environment_argument(parser)
         AppsignalCLICommand._push_api_key_argument(parser)
 
     def run(self) -> int:
         # Prompt for all the required config in a sensible order
         self._name  # noqa: B018
+        self._environment  # noqa: B018
         self._push_api_key  # noqa: B018
 
         client = Client(
             active=True,
+            environment=self._environment,
             name=self._name,
             push_api_key=self._push_api_key,
         )

--- a/src/appsignal/cli/demo.py
+++ b/src/appsignal/cli/demo.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from argparse import ArgumentParser
+
 from opentelemetry import trace
 
 from ..client import Client
@@ -10,7 +12,15 @@ from .command import AppsignalCLICommand
 class DemoCommand(AppsignalCLICommand):
     """Run demo application."""
 
+    @staticmethod
+    def init_parser(parser: ArgumentParser) -> None:
+        AppsignalCLICommand._application_argument(parser)
+        AppsignalCLICommand._push_api_key_argument(parser)
+
     def run(self) -> int:
+        # Prompt for all the required config in a sensible order
+        self._name  # noqa: B018
+        self._push_api_key  # noqa: B018
 
         client = Client(
             active=True,

--- a/src/appsignal/cli/install.py
+++ b/src/appsignal/cli/install.py
@@ -5,6 +5,7 @@ from argparse import ArgumentParser
 
 import requests
 
+from ..config import Config
 from .command import AppsignalCLICommand
 from .demo import DemoCommand
 
@@ -58,6 +59,7 @@ class InstallCommand(AppsignalCLICommand):
 
             demo = DemoCommand(args=self.args)
             demo._name = self._name
+            demo._environment = Config.DEFAULT_ENVIRONMENT
             demo._push_api_key = self._push_api_key
             print()
             demo.run()

--- a/src/appsignal/cli/install.py
+++ b/src/appsignal/cli/install.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from argparse import ArgumentParser
 
 import requests
 
@@ -22,6 +23,11 @@ INSTALL_FILE_NAME = "__appsignal__.py"
 
 class InstallCommand(AppsignalCLICommand):
     """Generate Appsignal client integration code."""
+
+    @staticmethod
+    def init_parser(parser: ArgumentParser) -> None:
+        AppsignalCLICommand._application_argument(parser)
+        AppsignalCLICommand._push_api_key_argument(parser)
 
     def run(self) -> int:
         # Make sure to show input prompts before the welcome text.

--- a/src/appsignal/cli/install.py
+++ b/src/appsignal/cli/install.py
@@ -53,6 +53,7 @@ class InstallCommand(AppsignalCLICommand):
             demo = DemoCommand(args=self.args)
             demo._name = self._name
             demo._push_api_key = self._push_api_key
+            print()
             demo.run()
 
             if self._search_dependency("django"):

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -75,13 +75,14 @@ class Config:
     CA_FILE_PATH = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "resources", "cacert.pem"
     )
+    DEFAULT_ENVIRONMENT = "development"
     DEFAULT_CONFIG = Options(
         ca_file_path=CA_FILE_PATH,
         diagnose_endpoint="https://appsignal.com/diag",
         enable_host_metrics=True,
         enable_nginx_metrics=False,
         enable_statsd=False,
-        environment="development",
+        environment=DEFAULT_ENVIRONMENT,
         endpoint="https://push.appsignal.com",
         files_world_accessible=True,
         log="file",

--- a/tests/cli/test_demo.py
+++ b/tests/cli/test_demo.py
@@ -23,7 +23,7 @@ def test_demo_with_valid_config(mocker, capfd):
         assert main(["demo"]) == 0  # Successful run
 
     out, err = capfd.readouterr()
-    assert out.find("Sending example data to AppSignal...") > 0
+    assert out.find("Sending example data to AppSignal...") > -1
 
 
 def test_demo_with_invalid_config(mocker, capfd):
@@ -35,4 +35,4 @@ def test_demo_with_invalid_config(mocker, capfd):
         assert main(["demo"]) == 1  # Exit with error
 
     out, err = capfd.readouterr()
-    assert out.strip() == "AppSignal not starting: no active config found."
+    assert out.find("AppSignal not starting: no active config found.") > -1

--- a/tests/cli/test_demo.py
+++ b/tests/cli/test_demo.py
@@ -18,9 +18,30 @@ def test_demo_with_valid_config(mocker, capfd):
     with mock_input(
         mocker,
         ("Please enter the name of your application: ", "My app name"),
+        (
+            "Please enter the application environment (development/production): ",
+            "development",
+        ),
         ("Please enter your Push API key: ", "000"),
     ):
         assert main(["demo"]) == 0  # Successful run
+
+    out, err = capfd.readouterr()
+    assert out.find("Sending example data to AppSignal...") > -1
+
+
+def test_demo_with_cli_options(mocker, capfd):
+    assert (
+        main(
+            [
+                "demo",
+                "--application=Test",
+                "--environment=development",
+                "--push-api-key=000",
+            ]
+        )
+        == 0  # Successful run
+    )
 
     out, err = capfd.readouterr()
     assert out.find("Sending example data to AppSignal...") > -1
@@ -30,6 +51,10 @@ def test_demo_with_invalid_config(mocker, capfd):
     with mock_input(
         mocker,
         ("Please enter the name of your application: ", "My app name"),
+        (
+            "Please enter the application environment (development/production): ",
+            "development",
+        ),
         ("Please enter your Push API key: ", " "),  # Invalid empty key
     ):
         assert main(["demo"]) == 1  # Exit with error


### PR DESCRIPTION
## Move empty line print from demo CLI to install CLI

Move the empty line print to the install CLI so that the demo CLI doesn't start with an empty line. Update the tests to match.

## Define CLI options in each CLI class

Instead of defining some defaults in the main CLI class, explicitly define them per CLI command, so it's easier to customize the CLI options per command.

## Add demo CLI --environment option

Allow users to specify which environment they want to send the demo samples for. Normally it defaults to the `development` environment.

For the install CLI (which calls the demo CLI), it will continue to default to the development environment like our other integrations.

Part of #138

---

Based on #146  
