### PR TITLE
Load __appsignal__.py file when found in demo CLI

### DIFF
--- a/.changesets/load-__appsignal__-py-file-in-demo-cli.md
+++ b/.changesets/load-__appsignal__-py-file-in-demo-cli.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+When the `__appsignal__.py` file is found in the directory in which the demo CLI (`python -m appsignal demo`) is run, the AppSignal will now load the `__appsignal__.py`. When this configuration file is loaded, the demo CLI will use the configuration declared in that file to send the demo data to AppSignal. In this scenario, it will no longer prompt you to enter the application configuration manually.

--- a/src/appsignal/cli/demo.py
+++ b/src/appsignal/cli/demo.py
@@ -39,6 +39,14 @@ class DemoCommand(AppsignalCLICommand):
         print(f"Starting AppSignal client for {self._name}...")
         client.start()
 
+        Demo.transmit()
+
+        return 0
+
+
+class Demo:
+    @staticmethod
+    def transmit() -> None:
         tracer = trace.get_tracer(__name__)
 
         # Performance sample
@@ -66,5 +74,3 @@ class DemoCommand(AppsignalCLICommand):
                 raise ValueError("Something went wrong")
             except ValueError as e:
                 span.record_exception(e)
-
-        return 0

--- a/src/appsignal/cli/install.py
+++ b/src/appsignal/cli/install.py
@@ -5,9 +5,9 @@ from argparse import ArgumentParser
 
 import requests
 
-from ..config import Config
+from ..client import Client
 from .command import AppsignalCLICommand
-from .demo import DemoCommand
+from .demo import Demo
 
 
 INSTALL_FILE_TEMPLATE = """from appsignal import Appsignal
@@ -56,13 +56,15 @@ class InstallCommand(AppsignalCLICommand):
             print(f"Writing the {INSTALL_FILE_NAME} configuration file...")
             self._write_file()
             print()
-
-            demo = DemoCommand(args=self.args)
-            demo._name = self._name
-            demo._environment = Config.DEFAULT_ENVIRONMENT
-            demo._push_api_key = self._push_api_key
             print()
-            demo.run()
+
+            client = Client(
+                active=True,
+                name=self._name,
+                push_api_key=self._push_api_key,
+            )
+            client.start()
+            Demo.transmit()
 
             if self._search_dependency("django"):
                 self._django_installation()

--- a/tests/cli/test_demo.py
+++ b/tests/cli/test_demo.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import os
+import shutil
 from contextlib import contextmanager
 
 from appsignal.cli.base import main
+from appsignal.cli.install import INSTALL_FILE_TEMPLATE
 
 
 @contextmanager
@@ -61,3 +64,87 @@ def test_demo_with_invalid_config(mocker, capfd):
 
     out, err = capfd.readouterr()
     assert out.find("AppSignal not starting: no active config found.") > -1
+
+
+def test_demo_with_config_file(request, mocker, capfd):
+    test_dir = os.path.join(os.getcwd(), "tmp/dummy_project")
+    if os.path.exists(test_dir):
+        shutil.rmtree(test_dir)
+    os.makedirs(test_dir)
+    # Change to test dir
+    os.chdir(test_dir)
+    # Add client file
+    with open(os.path.join(test_dir, "__appsignal__.py"), "w") as f:
+        file_contents = INSTALL_FILE_TEMPLATE.format(
+            name="My app name",
+            push_api_key="000",
+        )
+        f.write(file_contents)
+
+    assert main(["demo"]) == 0  # Successful run
+
+    # Change back to original dir
+    os.chdir(request.config.invocation_params.dir)
+
+    out, err = capfd.readouterr()
+    assert out.find("Sending example data to AppSignal...") > -1
+    assert out.find("Starting AppSignal client for My app name...") > -1
+
+
+def test_demo_with_config_file_and_cli_options(request, mocker, capfd):
+    test_dir = os.path.join(os.getcwd(), "tmp/dummy_project")
+    if os.path.exists(test_dir):
+        shutil.rmtree(test_dir)
+    os.makedirs(test_dir)
+    # Change to test dir
+    os.chdir(test_dir)
+    # Add client file
+    with open(os.path.join(test_dir, "__appsignal__.py"), "w") as f:
+        file_contents = INSTALL_FILE_TEMPLATE.format(
+            name="My app name",
+            push_api_key="000",
+        )
+        f.write(file_contents)
+
+    assert main(["demo", "--application=CLI app"]) == 0  # Successful run
+
+    # Change back to original dir
+    os.chdir(request.config.invocation_params.dir)
+
+    out, err = capfd.readouterr()
+    assert out.find("Sending example data to AppSignal...") > -1
+    assert out.find("Starting AppSignal client for CLI app...") > -1
+
+
+def test_demo_with_invalid_config_file(request, mocker, capfd):
+    test_dir = os.path.join(os.getcwd(), "tmp/dummy_project")
+    if os.path.exists(test_dir):
+        shutil.rmtree(test_dir)
+    os.makedirs(test_dir)
+    # Change to test dir
+    os.chdir(test_dir)
+    # Add invalid client file that doesn't assign the client to a variable
+    # named `appsignal`
+    with open(os.path.join(test_dir, "__appsignal__.py"), "w") as f:
+        file_contents = """from appsignal import Appsignal
+
+Appsignal(
+    active=True,
+    name="{name}",
+    push_api_key="{push_api_key}",
+)
+"""
+        f.write(file_contents)
+
+    assert main(["demo", "--application=CLI app"]) == 1  # Exit with error
+
+    # Change back to original dir
+    os.chdir(request.config.invocation_params.dir)
+
+    out, err = capfd.readouterr()
+    assert (
+        out.find(
+            "No `appsignal` variable exported by the __appsignal__.py config file."
+        )
+        > -1
+    )


### PR DESCRIPTION
## Extract demo samples creation to Demo class

Create the demo samples in its own class, separate from the configuration. This makes it more easily called by other parts of the package, like the install CLI.

The install CLI will configure the client on its own, as it uses different arguments than the demo CLI. Passing the CLI arguments along will cause an error if the demo if it calls demo CLI specific arguments that aren't part of the install CLI.

## Load __appsignal__.py file when found in demo CLI

When the demo CLI finds a `__appsignal__.py` configuration file, use that for the configuration, rather than only rely on the CLI prompt.

The demo CLI will overwrite the `active` config option to always be true when loading the file config.

One install test failed, because it expects a real file to be present and I didn't want to add more mocking to account for that. Instead, it now doesn't mock and uses a dummy project on the file system.

Part of #142
