### PR TITLE
Fix diagnose loading config for agent diagnose

### DIFF
--- a/.changesets/fix-agent-diagnostic-report-in-diagnose-cli-tool.md
+++ b/.changesets/fix-agent-diagnostic-report-in-diagnose-cli-tool.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix the agent diagnostic report in diagnose CLI tool (`python -m appsignal diagnose`). The agent diagnose report would always contain an error, because it did not pick up the AppSignal configuration properly. There's still an issue that it does not read from the `__appsignal__.py` configuration file, which will be addressed later.

--- a/src/appsignal/agent.py
+++ b/src/appsignal/agent.py
@@ -28,8 +28,11 @@ class Agent:
             out = output.decode("utf-8")
             print(f"AppSignal agent is unable to start ({returncode}): ", out)
 
-    def diagnose(self) -> bytes:
-        return subprocess.run([self.path, "diagnose"], capture_output=True).stdout
+    def diagnose(self, config: Config) -> bytes:
+        config.set_private_environ()
+        return subprocess.run(
+            [self.path, "diagnose", "--private"], capture_output=True
+        ).stdout
 
     def version(self) -> bytes:
         return subprocess.run(

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -95,9 +95,9 @@ class DiagnoseCommand(AppsignalCLICommand):
             print("Error: Cannot use --send-report and --no-send-report together.")
             return 1
 
-        agent = Agent()
-        agent_json = json.loads(agent.diagnose())
         self.config = Config()
+        agent = Agent()
+        agent_json = json.loads(agent.diagnose(self.config))
         self.agent_report = AgentReport(agent_json)
 
         self.report = {

--- a/tests/cli/test_diagnose.py
+++ b/tests/cli/test_diagnose.py
@@ -23,6 +23,13 @@ def test_diagnose_with_valid_config(mocker, capfd):
 
     out, err = capfd.readouterr()
     assert out.find("AppSignal diagnose") > -1
+    assert out.find("Agent tests\n    Started: started") > -1
+    # Check if the agent picks up the config. This is the first check that
+    # would fail.
+    assert out.find('RequiredEnvVarNotPresent("_APPSIGNAL_APP_ENV")') == -1
+    # TODO: fix in https://github.com/appsignal/appsignal-python/issues/142
+    # assert out.find("Configuration: invalid") == -1
+    # assert out.find("RequiredEnvVarNotPresent(\"_APPSIGNAL_PUSH_API_KEY\")") == -1
 
 
 def test_diagnose_with_cli_options(mocker, capfd):
@@ -54,3 +61,6 @@ def test_diagnose_with_invalid_config(mocker, capfd):
 
     out, err = capfd.readouterr()
     assert out.find("AppSignal diagnose") > -1
+
+    # Check if the agent tests fail. This is the first check that would fail.
+    assert out.find('RequiredEnvVarNotPresent("_APPSIGNAL_PUSH_API_KEY")') > -1


### PR DESCRIPTION
The diagnose CLI tool did not configure the agent diagnose run with the configuration. As a result it would always fail the agent diagnose tests.

Set the private env vars using the `Config.set_private_environ` method and update the subprocess run of the agent with the `--private` flag to read the right private environment variables format.

Fixes #141
Based on #148 
Related diagnose tests PR: https://github.com/appsignal/diagnose_tests/pull/96