### PR TITLE
Load __appsignal__.py file when found in diagnose 

### DIFF
--- a/.changesets/fix-agent-diagnostic-report-in-diagnose-cli-tool.md
+++ b/.changesets/fix-agent-diagnostic-report-in-diagnose-cli-tool.md
@@ -3,4 +3,4 @@ bump: "patch"
 type: "fix"
 ---
 
-Fix the agent diagnostic report in diagnose CLI tool (`python -m appsignal diagnose`). The agent diagnose report would always contain an error, because it did not pick up the AppSignal configuration properly. There's still an issue that it does not read from the `__appsignal__.py` configuration file, which will be addressed later.
+Fix the agent diagnostic report in diagnose CLI tool (`python -m appsignal diagnose`). The agent diagnose report would always contain an error, because it did not pick up the AppSignal configuration properly.

--- a/.changesets/load-__appsignal__-py-file-in-demo-cli.md
+++ b/.changesets/load-__appsignal__-py-file-in-demo-cli.md
@@ -3,4 +3,4 @@ bump: "patch"
 type: "change"
 ---
 
-When the `__appsignal__.py` file is found in the directory in which the demo CLI (`python -m appsignal demo`) is run, the AppSignal will now load the `__appsignal__.py`. When this configuration file is loaded, the demo CLI will use the configuration declared in that file to send the demo data to AppSignal. In this scenario, it will no longer prompt you to enter the application configuration manually.
+When the `__appsignal__.py` file is found in the directory in which the demo and diagnose CLIs are run (`python -m appsignal demo` or `python -m appsignal diagnose`), AppSignal will now load the `__appsignal__.py` file's configuration. When this file is loaded, the demo and diagnose CLI will use the configuration declared in that file to send the demo data and compile a diagnose report. In this scenario, it will no longer prompt you to enter the application configuration manually.

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -13,6 +13,7 @@ import requests
 
 from ..__about__ import __version__
 from ..agent import Agent
+from ..client import Client, InvalidClientFileError
 from ..config import Config
 from ..push_api_key_validator import PushApiKeyValidator
 from .command import AppsignalCLICommand
@@ -95,7 +96,18 @@ class DiagnoseCommand(AppsignalCLICommand):
             print("Error: Cannot use --send-report and --no-send-report together.")
             return 1
 
-        self.config = Config()
+        try:
+            client = Client._load__appsignal__file()
+        except InvalidClientFileError as error:
+            print(f"Error: {error}")
+            print("Exiting.")
+            return 1
+
+        if client:
+            self.config = client._config
+        else:
+            self.config = Config()
+
         agent = Agent()
         agent_json = json.loads(agent.diagnose(self.config))
         self.agent_report = AgentReport(agent_json)

--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from logging import DEBUG, ERROR, INFO, WARNING, Logger
+from runpy import run_path
 from typing import TYPE_CHECKING, ClassVar
 
 from .agent import agent
@@ -25,6 +27,29 @@ class Client:
         "debug": DEBUG,
         "trace": DEBUG,
     }
+
+    # Load the AppSignal client from the app specific `__appsignal__.py` client
+    # file. This loads the user config, rather than our default config.
+    # If no client file is found it return `None`.
+    # If there's a problem with the client file it will raise an
+    # `InvalidClientFileError` with a message containing more details.
+    @staticmethod
+    def _load__appsignal__file() -> Client | None:
+        cwd = os.getcwd()
+        app_config_path = os.path.join(cwd, "__appsignal__.py")
+        if os.path.exists(app_config_path):
+            try:
+                return run_path(app_config_path)["appsignal"]
+            except KeyError as error:
+                raise InvalidClientFileError(
+                    "No `appsignal` variable was exported by the "
+                    "__appsignal__.py config file. "
+                    "Please update the __appsignal__.py file as described in "
+                    "our documentation: "
+                    "https://docs.appsignal.com/python/configuration.html"
+                ) from error
+
+        return None
 
     def __init__(self, **options: Unpack[Options]) -> None:
         self._config = Config(options)
@@ -70,3 +95,7 @@ class Client:
             )
         )
         self._logger.addHandler(handler)
+
+
+class InvalidClientFileError(Exception):
+    pass

--- a/tests/cli/test_demo.py
+++ b/tests/cli/test_demo.py
@@ -143,5 +143,6 @@ Appsignal(
 
     out, err = capfd.readouterr()
     assert (
-        "No `appsignal` variable exported by the __appsignal__.py config file." in out
+        "No `appsignal` variable was exported by the __appsignal__.py config file."
+        in out
     )


### PR DESCRIPTION
## Move app client file loading to Client class

Move the logic of loading the app's client file to the Client class. This makes it easier to reuse by other CLIs, like the diagnose tool.

## Load __appsignal__.py file when found in diagnose

When the diagnose CLI finds a `__appsignal__.py` configuration file, use that for the configuration.

Before, it relied on the default sources and environment variables, but there was no other way to load the configuration in the diagnose report.

Update the existing changeset, as it basically covers the same material, but for another CLI tool now too.

Closes #142
