### PR TITLE
Update substring assertions in tests

### DIFF
--- a/tests/cli/test_demo.py
+++ b/tests/cli/test_demo.py
@@ -30,7 +30,7 @@ def test_demo_with_valid_config(mocker, capfd):
         assert main(["demo"]) == 0  # Successful run
 
     out, err = capfd.readouterr()
-    assert out.find("Sending example data to AppSignal...") > -1
+    assert "Sending example data to AppSignal..." in out
 
 
 def test_demo_with_cli_options(mocker, capfd):
@@ -47,7 +47,7 @@ def test_demo_with_cli_options(mocker, capfd):
     )
 
     out, err = capfd.readouterr()
-    assert out.find("Sending example data to AppSignal...") > -1
+    assert "Sending example data to AppSignal..." in out
 
 
 def test_demo_with_invalid_config(mocker, capfd):
@@ -63,7 +63,7 @@ def test_demo_with_invalid_config(mocker, capfd):
         assert main(["demo"]) == 1  # Exit with error
 
     out, err = capfd.readouterr()
-    assert out.find("AppSignal not starting: no active config found.") > -1
+    assert "AppSignal not starting: no active config found." in out
 
 
 def test_demo_with_config_file(request, mocker, capfd):
@@ -87,8 +87,8 @@ def test_demo_with_config_file(request, mocker, capfd):
     os.chdir(request.config.invocation_params.dir)
 
     out, err = capfd.readouterr()
-    assert out.find("Sending example data to AppSignal...") > -1
-    assert out.find("Starting AppSignal client for My app name...") > -1
+    assert "Sending example data to AppSignal..." in out
+    assert "Starting AppSignal client for My app name..." in out
 
 
 def test_demo_with_config_file_and_cli_options(request, mocker, capfd):
@@ -112,8 +112,8 @@ def test_demo_with_config_file_and_cli_options(request, mocker, capfd):
     os.chdir(request.config.invocation_params.dir)
 
     out, err = capfd.readouterr()
-    assert out.find("Sending example data to AppSignal...") > -1
-    assert out.find("Starting AppSignal client for CLI app...") > -1
+    assert "Sending example data to AppSignal..." in out
+    assert "Starting AppSignal client for CLI app..." in out
 
 
 def test_demo_with_invalid_config_file(request, mocker, capfd):
@@ -143,8 +143,5 @@ Appsignal(
 
     out, err = capfd.readouterr()
     assert (
-        out.find(
-            "No `appsignal` variable exported by the __appsignal__.py config file."
-        )
-        > -1
+        "No `appsignal` variable exported by the __appsignal__.py config file." in out
     )

--- a/tests/cli/test_diagnose.py
+++ b/tests/cli/test_diagnose.py
@@ -22,11 +22,11 @@ def test_diagnose_with_valid_config(mocker, capfd):
         main(["diagnose"])
 
     out, err = capfd.readouterr()
-    assert out.find("AppSignal diagnose") > -1
-    assert out.find("Agent tests\n    Started: started") > -1
+    assert "AppSignal diagnose" in out
+    assert "Agent tests\n    Started: started" in out
     # Check if the agent picks up the config. This is the first check that
     # would fail.
-    assert out.find('RequiredEnvVarNotPresent("_APPSIGNAL_APP_ENV")') == -1
+    assert 'RequiredEnvVarNotPresent("_APPSIGNAL_APP_ENV")' not in out
     # TODO: fix in https://github.com/appsignal/appsignal-python/issues/142
     # assert out.find("Configuration: invalid") == -1
     # assert out.find("RequiredEnvVarNotPresent(\"_APPSIGNAL_PUSH_API_KEY\")") == -1
@@ -36,20 +36,15 @@ def test_diagnose_with_cli_options(mocker, capfd):
     main(["diagnose", "--no-send-report"])
 
     out, err = capfd.readouterr()
-    assert out.find("AppSignal diagnose") > -1
-    assert (
-        out.find("Not sending report. (Specified with the --no-send-report option.)")
-        > -1
-    )
+    assert "AppSignal diagnose" in out
+    assert "Not sending report. (Specified with the --no-send-report option.)" in out
 
 
 def test_diagnose_with_invalid_send_report_cli_options(mocker, capfd):
     assert main(["diagnose", "--send-report", "--no-send-report"]) == 1
 
     out, err = capfd.readouterr()
-    assert (
-        out.find("Error: Cannot use --send-report and --no-send-report together.") > -1
-    )
+    assert "Error: Cannot use --send-report and --no-send-report together." in out
 
 
 def test_diagnose_with_invalid_config(mocker, capfd):
@@ -60,7 +55,7 @@ def test_diagnose_with_invalid_config(mocker, capfd):
         main(["diagnose"])
 
     out, err = capfd.readouterr()
-    assert out.find("AppSignal diagnose") > -1
+    assert "AppSignal diagnose" in out
 
     # Check if the agent tests fail. This is the first check that would fail.
-    assert out.find('RequiredEnvVarNotPresent("_APPSIGNAL_PUSH_API_KEY")') > -1
+    assert 'RequiredEnvVarNotPresent("_APPSIGNAL_PUSH_API_KEY")' in out


### PR DESCRIPTION
Use `"str" in variable` to find substrings, rather than use the more verbose `variable.find("str")` method.

[skip changeset]
[skip review]