### PR TITLE
Add set_sql_body tracing helper

### DIFF
--- a/.changesets/add-set_sql_body-tracing-helper.md
+++ b/.changesets/add-set_sql_body-tracing-helper.md
@@ -1,0 +1,20 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add the `set_sql_body` tracing helper to set the body attribute on a span that contains a SQL query. When using this helper the given SQL query will be sanitized, reducing the chances of sending sensitive data to AppSignal.
+
+```python
+from appsignal import set_sql_body
+
+# Must be used in an instrumented context -- e.g. a Django or Flask handler
+def index():
+    set_sql_body("SELECT * FROM users WHERE 'password' = 'secret'")
+    # Will be stored as:
+    set_sql_body("SELECT * FROM users WHERE 'password' = ?")
+```
+
+When the `set_body` helper is also used, the `set_sql_body` overwrites the `set_body` attribute.
+
+More information about our [tracing helpers](https://docs.appsignal.com/python/instrumentation/instrumentation.html) can be found in our documentation.

--- a/.changesets/bump-agent-8260fa1.md
+++ b/.changesets/bump-agent-8260fa1.md
@@ -1,0 +1,10 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to 8260fa1
+
+- Add `appsignal.sql_body` magic span attribute for OpenTelemetry spans. When this attribute is detected, we store the value as the span/event body. This span is sanitized beforehand so it doesn't contain any sensitive data and helps to group events in our backend. When used in combination with the `appsignal.body` attribute, the new `appsignal.sql_body` attribute is leading.
+
+  More information on [AppSignal OpenTelemetry span attributes](https://docs.appsignal.com/opentelemetry/custom-instrumentation/attributes.html) can be found in our docs.

--- a/src/appsignal/__init__.py
+++ b/src/appsignal/__init__.py
@@ -13,6 +13,7 @@ from .tracing import (
     set_params,
     set_root_name,
     set_session_data,
+    set_sql_body,
     set_tag,
 )
 
@@ -20,6 +21,7 @@ from .tracing import (
 __all__ = [
     "Appsignal",
     "set_body",
+    "set_sql_body",
     "set_category",
     "set_custom_data",
     "set_header",

--- a/src/appsignal/tracing.py
+++ b/src/appsignal/tracing.py
@@ -77,6 +77,10 @@ def set_body(body: str, span: Span | None = None) -> None:
     _set_attribute("appsignal.body", body, span)
 
 
+def set_sql_body(body: str, span: Span | None = None) -> None:
+    _set_attribute("appsignal.sql_body", body, span)
+
+
 def set_namespace(namespace: str, span: Span | None = None) -> None:
     _set_attribute("appsignal.namespace", namespace, span)
 

--- a/src/scripts/agent.py
+++ b/src/scripts/agent.py
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-    "version": "e8207c1",
+    "version": "8260fa1",
     "mirrors": [
         "https://appsignal-agent-releases.global.ssl.fastly.net",
         "https://d135dj0rjqvssy.cloudfront.net",
@@ -12,131 +12,131 @@ APPSIGNAL_AGENT_CONFIG = {
     "triples": {
         "x86_64-darwin": {
             "static": {
-                "checksum": "b4f9460cee052fb278e854abd0253c62844cf872c1be8fec6f04474fbdbab6b7",
+                "checksum": "fd6d8b57640fc55456f3ec36d42a6a63c9e26cac86dbd95aad81fac88c6b5af8",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "58278abef93445374fd7d9b66c1004f61fc8c9b0a0a6c98627bf576df71f76f0",
+                "checksum": "485a12ae7a4d9cb98044aa3698a2f931f4270cea7d9dfd07cb72543cb6a927a0",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "universal-darwin": {
             "static": {
-                "checksum": "b4f9460cee052fb278e854abd0253c62844cf872c1be8fec6f04474fbdbab6b7",
+                "checksum": "fd6d8b57640fc55456f3ec36d42a6a63c9e26cac86dbd95aad81fac88c6b5af8",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "58278abef93445374fd7d9b66c1004f61fc8c9b0a0a6c98627bf576df71f76f0",
+                "checksum": "485a12ae7a4d9cb98044aa3698a2f931f4270cea7d9dfd07cb72543cb6a927a0",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-darwin": {
             "static": {
-                "checksum": "47ab9a2778483ed7c35844778eaa983809679a70642739f30ad8d18c2cd7a578",
+                "checksum": "7b5b1ddc055b9dfef1c65ce95bc772fa04b3c5d9034f8aa3a0fff4ec58ce8e4c",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "f8b6d8409e7fbc451891cfcfdb49b87b7b11f3bd619021ac54647ea5f552eee7",
+                "checksum": "92b52f5db4dc4b00138b01013ca13d56595c86b1adda906b2fee6f77b223ee66",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm64-darwin": {
             "static": {
-                "checksum": "47ab9a2778483ed7c35844778eaa983809679a70642739f30ad8d18c2cd7a578",
+                "checksum": "7b5b1ddc055b9dfef1c65ce95bc772fa04b3c5d9034f8aa3a0fff4ec58ce8e4c",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "f8b6d8409e7fbc451891cfcfdb49b87b7b11f3bd619021ac54647ea5f552eee7",
+                "checksum": "92b52f5db4dc4b00138b01013ca13d56595c86b1adda906b2fee6f77b223ee66",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm-darwin": {
             "static": {
-                "checksum": "47ab9a2778483ed7c35844778eaa983809679a70642739f30ad8d18c2cd7a578",
+                "checksum": "7b5b1ddc055b9dfef1c65ce95bc772fa04b3c5d9034f8aa3a0fff4ec58ce8e4c",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "f8b6d8409e7fbc451891cfcfdb49b87b7b11f3bd619021ac54647ea5f552eee7",
+                "checksum": "92b52f5db4dc4b00138b01013ca13d56595c86b1adda906b2fee6f77b223ee66",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux": {
             "static": {
-                "checksum": "dfecb037362aac064d6a697c3e4ce293136a8e459894b2928c0120c6393db22a",
+                "checksum": "f64418e91322e4399ae46c9382624e848457fb98acabb54580da16980144c7ec",
                 "filename": "appsignal-aarch64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "897f71d3c155cbce0149ea6c5e2e9592795c5979ddd2fc1fd235e133556fe420",
+                "checksum": "b91ad8f3f241461ae6c885a301ba8335df5a5049ab09c230992a039d63cdc4dc",
                 "filename": "appsignal-aarch64-linux-all-dynamic.tar.gz",
             },
         },
         "i686-linux": {
             "static": {
-                "checksum": "a98181bfc8c7557468253c863185f68907b0d2283023f318da26dae8f997b566",
+                "checksum": "e7efe64d5432b41be1f46b1cf7fd0e619885e260d3b06a504bd860156da37165",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "2ed7cce986083d7e354c519a3f102a7e939ebc3e116d1653ecba2819c728a222",
+                "checksum": "81cd02a0ce17b263fd4cecbf886d760d6a2076e1dd0a277a0724c410c8ff8427",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86-linux": {
             "static": {
-                "checksum": "a98181bfc8c7557468253c863185f68907b0d2283023f318da26dae8f997b566",
+                "checksum": "e7efe64d5432b41be1f46b1cf7fd0e619885e260d3b06a504bd860156da37165",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "2ed7cce986083d7e354c519a3f102a7e939ebc3e116d1653ecba2819c728a222",
+                "checksum": "81cd02a0ce17b263fd4cecbf886d760d6a2076e1dd0a277a0724c410c8ff8427",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux": {
             "static": {
-                "checksum": "3350aec725af61a3eeb83971c0ee1da6dee761df3f2099945dd5ced9a0193a50",
+                "checksum": "439699aa4762942764384575ff8b9b1b14133a49b2d83600b03e75bbeccf83a7",
                 "filename": "appsignal-x86_64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "cb8e94badcd8c56941bf43353b65cf57908e4f804d08c85df62f31b8b48844a0",
+                "checksum": "9751cef5e8d607bfa76bedbf0d8bed10fdfdcd285ba0daaa61fdc30534fdbaa4",
                 "filename": "appsignal-x86_64-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux-musl": {
             "static": {
-                "checksum": "eaab36b010bdc5b06ac4646b6d4ebb94523a9f852a2a2cbaba7738b3fade64d1",
+                "checksum": "91106eeca644d046e8f19372776dcc595c98c2aa5e9429de080bdc90c459e9ad",
                 "filename": "appsignal-x86_64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "b8c6082bd8ee6619854436c3395355f364d8a91d6edec64e0a37c098f26e9e3f",
+                "checksum": "f6b8283c8976de96892cce5e55bcda5aee95937e3593452b73dc5e4ce7ea1536",
                 "filename": "appsignal-x86_64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux-musl": {
             "static": {
-                "checksum": "ad371eabe4e2484f7fb980e8bb53d7b079a473d615cbb738271d36f7ad81c71f",
+                "checksum": "a095fb9a1747919093f5afaa3898da721b7c45a54f6b5d54ab2ac2d17c15025f",
                 "filename": "appsignal-aarch64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "9d609cecbaf90b8ad233efae5bc04e973f15077a9c361f6a4c9febcfff57fcb0",
+                "checksum": "2623a9e2f4311fcaba8d4a5dde86e9e743b8059f801c1a28cefcea3273e8685e",
                 "filename": "appsignal-aarch64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "x86_64-freebsd": {
             "static": {
-                "checksum": "b1b86d145b07b030788e1e5f21089efbda103f11ec3c11ff77c388aaa1856d4d",
+                "checksum": "2cf7c6c961b0745c6b700472e16f86c89cb53163e5624d7dfbe9fa4c8641e9a2",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "80550ade93ad62974f620e40f2ceb31b3b6304acc7d134964095ea7df4d3887f",
+                "checksum": "7c2a270e8d6d7582b5cef25ffaabdcc36077bbf3b295997ae1f1b33968a39fe8",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },
         "amd64-freebsd": {
             "static": {
-                "checksum": "b1b86d145b07b030788e1e5f21089efbda103f11ec3c11ff77c388aaa1856d4d",
+                "checksum": "2cf7c6c961b0745c6b700472e16f86c89cb53163e5624d7dfbe9fa4c8641e9a2",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "80550ade93ad62974f620e40f2ceb31b3b6304acc7d134964095ea7df4d3887f",
+                "checksum": "7c2a270e8d6d7582b5cef25ffaabdcc36077bbf3b295997ae1f1b33968a39fe8",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -16,6 +16,7 @@ from appsignal import (
     set_params,
     set_root_name,
     set_session_data,
+    set_sql_body,
     set_tag,
 )
 
@@ -36,7 +37,8 @@ def raised_error():
 
 def test_set_attributes(spans):
     with tracer.start_as_current_span("span"):
-        set_body("SELECT * FROM users")
+        set_body("Span body")
+        set_sql_body("SELECT * FROM users")
         set_category("some.query")
         set_name("Some query")
         set_custom_data({"chunky": "bacon"})
@@ -48,7 +50,8 @@ def test_set_attributes(spans):
         set_root_name("Root name")
 
     assert dict(spans()[0].attributes) == {
-        "appsignal.body": "SELECT * FROM users",
+        "appsignal.body": "Span body",
+        "appsignal.sql_body": "SELECT * FROM users",
         "appsignal.category": "some.query",
         "appsignal.name": "Some query",
         "appsignal.custom_data": '{"chunky": "bacon"}',
@@ -64,7 +67,8 @@ def test_set_attributes(spans):
 def test_set_attributes_on_span(spans):
     with tracer.start_as_current_span("parent span") as span:
         with tracer.start_as_current_span("child span"):
-            set_body("SELECT * FROM users", span)
+            set_body("Span body", span)
+            set_sql_body("SELECT * FROM users", span)
             set_category("some.query", span)
             set_name("Some query", span)
             set_custom_data({"chunky": "bacon"}, span)
@@ -80,7 +84,8 @@ def test_set_attributes_on_span(spans):
 
     parent_span = next(span for span in spans if span.name == "parent span")
     assert dict(parent_span.attributes) == {
-        "appsignal.body": "SELECT * FROM users",
+        "appsignal.body": "Span body",
+        "appsignal.sql_body": "SELECT * FROM users",
         "appsignal.category": "some.query",
         "appsignal.name": "Some query",
         "appsignal.custom_data": '{"chunky": "bacon"}',


### PR DESCRIPTION
Make it easier to set SQL queries as the span body attribute without danger of storing unsanitized SQL queries.

When `set_sql_body` is used in combination with `set_body`, the `set_sql_body` call is leading.

Part of https://github.com/appsignal/appsignal-python/issues/140
Required agent PR: https://github.com/appsignal/appsignal-agent/pull/1067