### PR TITLE
Refactor Push API key validation in install CLI

### DIFF
--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -54,7 +54,7 @@ def assert_wrote_real_file_contents(test_dir, name, push_api_key):
 
 
 def mock_validate_push_api_key_request(mocker, status_code=200):
-    mock_request = mocker.patch("requests.get")
+    mock_request = mocker.patch("requests.post")
     mock_request.return_value = MagicMock(status_code=status_code)
 
 


### PR DESCRIPTION
In the install CLI we had an almost identical code to the PushApiKeyValidator module present. I've updated it to use the PushApiKeyValidator module instead so we don't have a bunch of duplicate code.

Change the test to expect a POST request, instead of a GET request. The API doesn't care which HTTP request method is used, it listens to both type of request methods.

[skip changeset] as it's an internal change with no user visible change.