### PR TITLE
Bump package to version 1.0

### DIFF
--- a/.changesets/_release-1-0.md
+++ b/.changesets/_release-1-0.md
@@ -1,0 +1,28 @@
+---
+bump: "major"
+type: "add"
+---
+
+Release AppSignal for Python package version 1.0!
+
+This release marks the 1.0 release of our Python integration and contains the following features:
+
+- Track errors in your app.
+- Track performance of HTTP endpoints and background jobs.
+- Dive into more detail with custom instrumentation.
+- View host metrics for Virtual Machines and containers on which the app is running.
+- Report custom metrics that are unique to your app, and get alerted when they change.
+- Deploy tracking whenever a new version of your application gets deployed.
+- Automatic support for the following frameworks and libraries:
+    - Celery
+    - Django
+    - FastAPI
+    - Flask
+    - Jinja2
+    - Psycopg2
+    - Redis
+    - Requests
+    - Starlette
+    - WSGI/ASGI
+
+Please see [our Python package documentation](https://docs.appsignal.com/python) and [guides](https://docs.appsignal.com/guides.html) for more information. Reach out to us on [support@appsignal.com](mailto:support@appsignal.com) if you need any help 👋


### PR DESCRIPTION
Nothing in this release requires a major version bump, but as discussed, we are ready to release version 1.0 to communicate it's ready for use.

It's not feature complete: we don't have Python logging integration for example, but those features will be added a later time.

I created a small changeset that kind of summarizes what the package contains now, but this is not meant to replace the blog post announcement and we should update the changelog later to link to that instead. This is there now in case we release before a blog post is out.

The changeset file name starts with an underscore to hopefully put it on the top upon release.

---

This doesn't have to get merged right away. We can decide upon a good moment to merge it.

## To do

- [ ] Please merge after: https://github.com/appsignal/appsignal-python/pull/159
- [ ] Link to the announcement blog post.
- [ ] Update the changeset to only link to the blog post, if it's out before than this gets merged.