### PR TITLE
Fix and improve diagnose paths report output

### DIFF
--- a/.changesets/fix-diagnose-report-error-when-a-path-was-not-found.md
+++ b/.changesets/fix-diagnose-report-error-when-a-path-was-not-found.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix the diagnose report CLI exiting with an error when a path was not found. When a file, like the `appsignal.log` file, was not found, the diagnose CLI would exit with an error when trying to read from the file. It will now no longer try to read a non-existing file and no longer error.

--- a/.changesets/print-more-path-details-in-diagnose-cli-output.md
+++ b/.changesets/print-more-path-details-in-diagnose-cli-output.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+The diagnose CLI will now print more details about each path in diagnose CLI output, such as if it exists or not, if it's writable and the ownership details. This will help with debugging path related issues without sending the report to the AppSignal servers.

--- a/tests/cli/test_diagnose.py
+++ b/tests/cli/test_diagnose.py
@@ -119,3 +119,11 @@ Appsignal(
         "No `appsignal` variable was exported by the __appsignal__.py config file."
         in out
     )
+
+
+def test_diagnose_with_missing_paths(mocker, capfd):
+    mocker.patch("appsignal.cli.diagnose.PathsReport._file_exists", return_value=False)
+    assert main(["diagnose", "--no-send-report"]) == 0
+
+    out, err = capfd.readouterr()
+    assert "Exists?: False" in out


### PR DESCRIPTION
This change was originally prompted by the bug reported in #158. If the `appsignal.log` file could not be found, it would exit with an error when trying to read the log file.

While fixing this, I noticed the paths subreport didn't print the same output as other integrations. While fixing this I refactored how the paths subreport is generated, which also includes the fix. It was more work to split the fix out or fix it first, than include it in the refactor.

The fix is to early return from the method doing all the information gathering about a path (directory/file) when it does not exist with this if-statement in the `PathsReport._path_metadata` method:

```python
if not info["exists"]:
    return info
```

The refactor moves the paths data gathering to a new PathsReport class for better organization. It defines which paths exists and iterates over them to fetch the metadata and generate the paths subreport. This new implementation reduces duplication in definitions of paths and path output, and removes a second method that also read the file contents. Instead the CLI will only print the last 10 lines of file contents using the full file contents value (which is the last 2MB of the file).

Fixes #158