### PR TITLE
Fix push API key validation on installer

### DIFF
--- a/.changesets/fix-push-api-key-validation.md
+++ b/.changesets/fix-push-api-key-validation.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix an issue where the installer would always find the push API key to be invalid, halting the installation process.

--- a/src/appsignal/cli/command.py
+++ b/src/appsignal/cli/command.py
@@ -6,8 +6,6 @@ from argparse import ArgumentParser, Namespace
 from dataclasses import dataclass
 from functools import cached_property
 
-from ..config import Config
-
 
 @dataclass(frozen=True)
 class AppsignalCLICommand(ABC):
@@ -68,7 +66,3 @@ class AppsignalCLICommand(ABC):
                 "Please enter the application environment (development/production): "
             )
         return environment
-
-    @cached_property
-    def _config(self) -> Config:
-        return Config()

--- a/src/appsignal/cli/install.py
+++ b/src/appsignal/cli/install.py
@@ -4,6 +4,7 @@ import os
 from argparse import ArgumentParser
 
 from ..client import Client
+from ..config import Config, Options
 from ..push_api_key_validator import PushApiKeyValidator
 from .command import AppsignalCLICommand
 from .demo import Demo
@@ -30,9 +31,11 @@ class InstallCommand(AppsignalCLICommand):
         AppsignalCLICommand._push_api_key_argument(parser)
 
     def run(self) -> int:
+        options = Options()
+
         # Make sure to show input prompts before the welcome text.
-        self._name  # noqa: B018
-        self._push_api_key  # noqa: B018
+        options["name"] = self._name
+        options["push_api_key"] = self._push_api_key
 
         print("👋 Welcome to the AppSignal for Python installer!")
         print()
@@ -44,7 +47,7 @@ class InstallCommand(AppsignalCLICommand):
 
         print("Validating API key")
         print()
-        validation_result = PushApiKeyValidator.validate(self._config)
+        validation_result = PushApiKeyValidator.validate(Config(options))
         if validation_result == "valid":
             print("API key is valid!")
         elif validation_result == "invalid":


### PR DESCRIPTION
The configuration obtained from the installer prompts was not being passed correctly to the installer.

Fixes #161.