### PR TITLE
Add push API key message to client file template

### DIFF
--- a/.changesets/add-warning-to-client-file.md
+++ b/.changesets/add-warning-to-client-file.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Add a message about committing the Push API key in the client file upon generation. We recommend storing this key in environment variables instead or in some kind of separate credentials system instead.

--- a/src/appsignal/cli/install.py
+++ b/src/appsignal/cli/install.py
@@ -15,6 +15,9 @@ INSTALL_FILE_TEMPLATE = """from appsignal import Appsignal
 appsignal = Appsignal(
     active=True,
     name="{name}",
+    # Please do not commit this key to your source control management system.
+    # Move this to your app's security credentials or environment variables.
+    # https://docs.appsignal.com/python/configuration/options.html#option-push_api_key
     push_api_key="{push_api_key}",
 )
 """

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -14,6 +14,9 @@ EXPECTED_FILE_CONTENTS = """from appsignal import Appsignal
 appsignal = Appsignal(
     active=True,
     name="My app name",
+    # Please do not commit this key to your source control management system.
+    # Move this to your app's security credentials or environment variables.
+    # https://docs.appsignal.com/python/configuration/options.html#option-push_api_key
     push_api_key="My push API key",
 )
 """


### PR DESCRIPTION
When we generate an `__appsignal__.py` file in the install CLI, also add a message about not committing this key to Git, but move it to some other system instead.