### PR TITLE
Fix the demo samples recognition and use a custom DemoError class

### DIFF
--- a/.changesets/fix-demo-error-and-performance-incidents.md
+++ b/.changesets/fix-demo-error-and-performance-incidents.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix the demo error and performance incidents that are reported by our install and demo CLI tools to recognize them by our front-end as examples. It will now show the intended box with some additional explanation that you don't have to worry about these example errors and performance measurements. They're there to test if our integration works in your app and report the first bits of data.

--- a/.changesets/rename-example-error-reported-by-our-installer-and-demo-clis.md
+++ b/.changesets/rename-example-error-reported-by-our-installer-and-demo-clis.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Rename the example error reported by our installer and demo CLIs from `ValueError` to `DemoError` to better communicate this is an example error and should not be treated as a real error from the app.

--- a/src/appsignal/cli/demo.py
+++ b/src/appsignal/cli/demo.py
@@ -5,7 +5,7 @@ from argparse import ArgumentParser
 from opentelemetry import trace
 
 from ..client import Client, InvalidClientFileError
-from ..tracing import set_params
+from ..tracing import set_params, set_tag
 from .command import AppsignalCLICommand
 
 
@@ -78,19 +78,13 @@ class Demo:
                 "otel.instrumentation_library.name",
                 "opentelemetry.instrumentation.wsgi",
             )
-            span.set_attribute(
-                "demo_sample",
-                True,
-            )
+            set_tag("demo_sample", True, span)
 
         # Error sample
         with tracer.start_as_current_span("GET /demo") as span:
             span.set_attribute("http.method", "GET")
             set_params({"GET": {"id": 1}, "POST": {}}, span)
-            span.set_attribute(
-                "demo_sample",
-                True,
-            )
+            set_tag("demo_sample", True, span)
             try:
                 raise ValueError("Something went wrong")
             except ValueError as e:

--- a/src/appsignal/cli/demo.py
+++ b/src/appsignal/cli/demo.py
@@ -86,6 +86,10 @@ class Demo:
             set_params({"GET": {"id": 1}, "POST": {}}, span)
             set_tag("demo_sample", True, span)
             try:
-                raise ValueError("Something went wrong")
-            except ValueError as e:
+                raise DemoError("Something went wrong")
+            except DemoError as e:
                 span.record_exception(e)
+
+
+class DemoError(Exception):
+    pass


### PR DESCRIPTION
## Fix the demo samples recognition in the front-end

To display the demo samples message for the first error reported by our integration, fix how the `demo_sample` tag is set.

It should be set as a tag, using the magic attribute, not by directly setting an OpenTelemetry span attribute.

## Use custom DemoError class for Demo error sample

We reported the demo error as a ValueError, which is a normal error in Python. This might have people think something is wrong immediately. Use the custom `DemoError` class to communicate that it's just an example error. This matches how we report this error name in other integrations.
