### PR TITLE
Use the `set_error` helper in the demo CLI

### DIFF
--- a/src/appsignal/cli/demo.py
+++ b/src/appsignal/cli/demo.py
@@ -5,7 +5,7 @@ from argparse import ArgumentParser
 from opentelemetry import trace
 
 from ..client import Client, InvalidClientFileError
-from ..tracing import set_params, set_tag
+from ..tracing import set_error, set_params, set_tag
 from .command import AppsignalCLICommand
 
 
@@ -88,7 +88,7 @@ class Demo:
             try:
                 raise DemoError("Something went wrong")
             except DemoError as e:
-                span.record_exception(e)
+                set_error(e, span)
 
 
 class DemoError(Exception):


### PR DESCRIPTION
Report the error using our own `set_error` helper, rather than the OpenTelemetry way. This makes it more consistent how the sample data is set for all samples in for the demo module.

[skip changeset] it's an internal change we release whenever we want.