### PR TITLE
Update CHANGELOG with link to blog post for v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### Added
 
 - [c1b31b8](https://github.com/appsignal/appsignal-python/commit/c1b31b8e9fac34bf5e5056400fa735295d191cfd) major - Release AppSignal for Python package version 1.0!
-  
+
+  Read our [Python package version 1.0 announcement blog post](blog.appsignal.com/2023/10/31/appsignal-monitoring-available-for-python-applications.html)!
+
   This release marks the 1.0 release of our Python integration and contains the following features:
   
   - Track errors in your app.


### PR DESCRIPTION
Link to the blog post that goes into more detail about the release.

---

[skip review]
[skip changeset]

## To do

- [x] Merge once https://github.com/appsignal/appsignal-nextjs-blog/pull/1000 is deployed.
- [ ] Update public changelog