### PR TITLE
Report agent architecture and platform in diagnose

### DIFF
--- a/.changesets/report-agent-architecture-and-platform-in-diagnose-report.md
+++ b/.changesets/report-agent-architecture-and-platform-in-diagnose-report.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Report the agent's architecture and platform in the diagnose report as the "Agent architecture" field. This helps debug if the installed package version matches the host architecture and platform. If they do not match, the package for the wrong architecture is installed.

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 __pycache__
 /dist
 /src/appsignal/appsignal-agent
+/src/appsignal/_appsignal_platform
 /tmp
 /.coverage
 /htmlcov/

--- a/mono.yml
+++ b/mono.yml
@@ -4,7 +4,7 @@ repo: "https://github.com/appsignal/appsignal-python"
 bootstrap:
   command: ""
 clean:
-  command: "hatch clean; rm -r tmp; rm src/appsignal/appsignal-agent"
+  command: "hatch clean; rm -rf tmp; rm -f src/appsignal/appsignal-agent"
 build:
   command: "mono clean; hatch run build:all"
 publish:

--- a/src/appsignal/agent.py
+++ b/src/appsignal/agent.py
@@ -9,13 +9,15 @@ from .config import Config
 
 @dataclass
 class Agent:
-    path: Path = Path(__file__).parent / "appsignal-agent"
+    package_path: Path = Path(__file__).parent
+    agent_path: Path = package_path / "appsignal-agent"
+    platform_path: Path = package_path / "_appsignal_platform"
     active: bool = False
 
     def start(self, config: Config) -> None:
         config.set_private_environ()
         p = subprocess.Popen(
-            [self.path, "start", "--private"],
+            [self.agent_path, "start", "--private"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
@@ -31,13 +33,17 @@ class Agent:
     def diagnose(self, config: Config) -> bytes:
         config.set_private_environ()
         return subprocess.run(
-            [self.path, "diagnose", "--private"], capture_output=True
+            [self.agent_path, "diagnose", "--private"], capture_output=True
         ).stdout
 
     def version(self) -> bytes:
         return subprocess.run(
-            [self.path, "--version"], capture_output=True
+            [self.agent_path, "--version"], capture_output=True
         ).stdout.split()[-1]
+
+    def architecutre_and_platform(self) -> list[str]:
+        with open(self.platform_path) as file:
+            return file.read().split("-", 1)
 
 
 agent = Agent()

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -181,6 +181,8 @@ class DiagnoseCommand(AppsignalCLICommand):
         self.agent_report = AgentReport(agent_json)
         self.paths_report = PathsReport(self.config)
 
+        package_arch, package_platform = agent.architecutre_and_platform()
+
         self.report = {
             "agent": {
                 "agent": {
@@ -210,6 +212,8 @@ class DiagnoseCommand(AppsignalCLICommand):
                 "language": "python",
                 "package_version": __version__,
                 "agent_version": str(agent.version(), "utf-8"),
+                "package_architecture": package_arch,
+                "package_platform": package_platform,
             },
             "paths": self.paths_report.report(),
             "process": {
@@ -263,6 +267,8 @@ class DiagnoseCommand(AppsignalCLICommand):
         print("  Language: Python")
         print(f'  Package version: "{library_report["package_version"]}"')
         print(f'  Agent version: "{library_report["agent_version"]}"')
+        print(f'  Package architecture: "{library_report["package_architecture"]}"')
+        print(f'  Package platform: "{library_report["package_platform"]}"')
 
     def _host_information(self) -> None:
         host_report: Any = self.report["host"]

--- a/src/scripts/build_hook.py
+++ b/src/scripts/build_hook.py
@@ -102,6 +102,9 @@ class CustomBuildHook(BuildHookInterface):
         build_data["pure_python"] = False
 
         agent_path = os.path.join(self.root, "src", "appsignal", "appsignal-agent")
+        platform_path = os.path.join(
+            self.root, "src", "appsignal", "_appsignal_platform"
+        )
 
         if os.environ.get(
             "_APPSIGNAL_BUILD_AGENT_PATH", ""
@@ -116,6 +119,7 @@ class CustomBuildHook(BuildHookInterface):
 
         tempagent_path = os.path.join(tempdir_path, "appsignal_agent")
         tempversion_path = os.path.join(tempdir_path, "version")
+        tempplatform_path = os.path.join(tempdir_path, "platform")
 
         if os.environ.get("_APPSIGNAL_BUILD_AGENT_PATH", "").strip() != "":
             tempagent_path = os.path.abspath(
@@ -134,6 +138,7 @@ class CustomBuildHook(BuildHookInterface):
 
             rm(tempagent_path)
             rm(tempversion_path)
+            rm(tempplatform_path)
             rm(temptar_path)
 
             with open(temptar_path, "wb") as temptar:
@@ -171,12 +176,16 @@ class CustomBuildHook(BuildHookInterface):
             with open(tempversion_path, "w") as version:
                 version.write(APPSIGNAL_AGENT_CONFIG["version"])
 
+            with open(tempplatform_path, "w") as platform:
+                platform.write(triple)
+
             print(f"Extracted agent binary to {tempagent_path}")
             rm(temptar_path)
         else:
             print(f"Using cached agent binary at {tempagent_path}")
 
         shutil.copy(tempagent_path, agent_path)
+        shutil.copy(tempplatform_path, platform_path)
         os.chmod(agent_path, stat.S_IEXEC | stat.S_IREAD | stat.S_IWRITE)
 
         print(f"Copied agent binary to {agent_path}")


### PR DESCRIPTION
## Don't fail mono clean when files don't exist

The `mono clean` command would fail when the `appsignal-agent` file did not exist. Add the `-f` flag to ignore that if it doesn't exist.

## Report agent architecture and platform in diagnose

We ship a separate package for every architecture and platform. The agent isn't installed upon package download/install, like in other integrations.

By adding the agent's architecture and platform, we know which package version was installed for which architecture and platform. Ship a `_appsignal_platform` file in the distributed package, which is then read by the diagnose CLI. I don't want the diagnose CLI to detect the host here, I want to know which release artifact (as pushed to pypi) was installed.
