### PR TITLE
Add package install path to the diagnose report

### DIFF
--- a/.changesets/report-the-package-install-path-in-the-diagnose-report.md
+++ b/.changesets/report-the-package-install-path-in-the-diagnose-report.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Report the package install path in the diagnose report as the "Package install path" field. This field will help us debug issues related to paths in the diagnose report viewer.

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -7,6 +7,7 @@ import os
 import platform
 import urllib
 from argparse import ArgumentParser
+from pathlib import Path
 from typing import Any
 
 import requests
@@ -83,6 +84,10 @@ class PathsReport:
         log_path = self.config.option("log_path") or os.path.dirname(log_file_path)
 
         return {
+            "package_install_path": {
+                "label": "Package install path",
+                "path": str(Path(__file__).parents[3]),
+            },
             "working_dir": {
                 "label": "Current working directory",
                 "path": os.getcwd() or "",


### PR DESCRIPTION
This will help debug path related issues in the diagnose report viewer.

Using the same technique I found in `src/appsignal/agent.py` to fetch the current file's path, but then navigate up twice to get the package's path.