### PR TITLE
Report running_in_container in diagnose report

### DIFF
--- a/.changesets/bump-agent-to-b604345.md
+++ b/.changesets/bump-agent-to-b604345.md
@@ -1,0 +1,12 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to b604345.
+
+- Add an exponential backoff to the retry sleep time to bind to the StatsD, NGINX and OpenTelemetry exporter ports. This gives the agent a longer time to connect to the ports if they become available within a 4 minute window.
+- Changes to the agent logger:
+  - Logs from the agent and extension now use a more consistent format in logs for spans and transactions.
+  - Logs that are for more internal use are moved to the trace log level and logs that are useful for debugging most support issues are moved to the debug log level. It should not be necessary to use log level 'trace' as often anymore. The 'debug' log level should be enough.
+- Add `running_in_container` to agent diagnose report, to be used primarily by the Python package as a way to detect if an app's host is a container or not.

--- a/.changesets/report-running_in_container-in-diagnose-report.md
+++ b/.changesets/report-running_in_container-in-diagnose-report.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Report whether the app is running in a container in the diagnose report as the "Running in container" field. This field will help notify us about the environment in which the app is running, as containers have different behavior from more standard Virtual Machines.

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -45,6 +45,9 @@ class AgentReport:
     def group_id(self) -> str:
         return self.report["host"]["gid"]["result"]
 
+    def running_in_container(self) -> str:
+        return self.report["host"]["running_in_container"]["result"]
+
     def logger_started(self) -> str:
         if "logger" in self.report:
             if self.report["logger"]["started"]["result"]:
@@ -208,6 +211,7 @@ class DiagnoseCommand(AppsignalCLICommand):
             "host": {
                 "architecture": platform.machine(),
                 "heroku": os.environ.get("DYNO") is not None,
+                "running_in_container": self.agent_report.running_in_container(),
                 "language_version": platform.python_version(),
                 "os": platform.system().lower(),
                 "os_distribution": self._os_distribution(),
@@ -282,6 +286,7 @@ class DiagnoseCommand(AppsignalCLICommand):
         print(f'  Operating System: "{host_report["os"]}"')
         print(f'  Python version: "{host_report["language_version"]}"')
         print(f'  Root user: {host_report["root"]}')
+        print(f'  Running in container: {host_report["running_in_container"]}')
 
     def _agent_information(self) -> None:
         print("Agent diagnostics")

--- a/src/scripts/agent.py
+++ b/src/scripts/agent.py
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-    "version": "8260fa1",
+    "version": "b604345",
     "mirrors": [
         "https://appsignal-agent-releases.global.ssl.fastly.net",
         "https://d135dj0rjqvssy.cloudfront.net",
@@ -12,131 +12,131 @@ APPSIGNAL_AGENT_CONFIG = {
     "triples": {
         "x86_64-darwin": {
             "static": {
-                "checksum": "fd6d8b57640fc55456f3ec36d42a6a63c9e26cac86dbd95aad81fac88c6b5af8",
+                "checksum": "98ac31aa2ca05a18e5eb94a8ecee75b83bb7d973f0f7565a36815b95577aa727",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "485a12ae7a4d9cb98044aa3698a2f931f4270cea7d9dfd07cb72543cb6a927a0",
+                "checksum": "8e8558136ae11a4e29062a553555cbbf2097401b423a49d252dcac715b9e5ca6",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "universal-darwin": {
             "static": {
-                "checksum": "fd6d8b57640fc55456f3ec36d42a6a63c9e26cac86dbd95aad81fac88c6b5af8",
+                "checksum": "98ac31aa2ca05a18e5eb94a8ecee75b83bb7d973f0f7565a36815b95577aa727",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "485a12ae7a4d9cb98044aa3698a2f931f4270cea7d9dfd07cb72543cb6a927a0",
+                "checksum": "8e8558136ae11a4e29062a553555cbbf2097401b423a49d252dcac715b9e5ca6",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-darwin": {
             "static": {
-                "checksum": "7b5b1ddc055b9dfef1c65ce95bc772fa04b3c5d9034f8aa3a0fff4ec58ce8e4c",
+                "checksum": "228810d4d6c344cf6346d889b5eab4d23140a310d4e93465fb2bd461e4e4652e",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "92b52f5db4dc4b00138b01013ca13d56595c86b1adda906b2fee6f77b223ee66",
+                "checksum": "09e7f98873a890284b97b70cdc2ac4c2556ecefcc4b3f41238caad81ad3af10c",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm64-darwin": {
             "static": {
-                "checksum": "7b5b1ddc055b9dfef1c65ce95bc772fa04b3c5d9034f8aa3a0fff4ec58ce8e4c",
+                "checksum": "228810d4d6c344cf6346d889b5eab4d23140a310d4e93465fb2bd461e4e4652e",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "92b52f5db4dc4b00138b01013ca13d56595c86b1adda906b2fee6f77b223ee66",
+                "checksum": "09e7f98873a890284b97b70cdc2ac4c2556ecefcc4b3f41238caad81ad3af10c",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm-darwin": {
             "static": {
-                "checksum": "7b5b1ddc055b9dfef1c65ce95bc772fa04b3c5d9034f8aa3a0fff4ec58ce8e4c",
+                "checksum": "228810d4d6c344cf6346d889b5eab4d23140a310d4e93465fb2bd461e4e4652e",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "92b52f5db4dc4b00138b01013ca13d56595c86b1adda906b2fee6f77b223ee66",
+                "checksum": "09e7f98873a890284b97b70cdc2ac4c2556ecefcc4b3f41238caad81ad3af10c",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux": {
             "static": {
-                "checksum": "f64418e91322e4399ae46c9382624e848457fb98acabb54580da16980144c7ec",
+                "checksum": "aa36f82e040b86743fed514268dc1c7d83b14739dd65337a05bf2d994b83a3aa",
                 "filename": "appsignal-aarch64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "b91ad8f3f241461ae6c885a301ba8335df5a5049ab09c230992a039d63cdc4dc",
+                "checksum": "99f0c57c2ebb7677512284a11cc375ac95d97b0ec89d6f5b33243a81bcd0123b",
                 "filename": "appsignal-aarch64-linux-all-dynamic.tar.gz",
             },
         },
         "i686-linux": {
             "static": {
-                "checksum": "e7efe64d5432b41be1f46b1cf7fd0e619885e260d3b06a504bd860156da37165",
+                "checksum": "7ce2f5ed5a0f0b4ad574e897d6cd0e5912928b211b307b20b6837c1bcbfaf640",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "81cd02a0ce17b263fd4cecbf886d760d6a2076e1dd0a277a0724c410c8ff8427",
+                "checksum": "5ba15d9836b0db556a55919b32995a2c10eaf9433050ae4a1d0bd2baf8ce70fb",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86-linux": {
             "static": {
-                "checksum": "e7efe64d5432b41be1f46b1cf7fd0e619885e260d3b06a504bd860156da37165",
+                "checksum": "7ce2f5ed5a0f0b4ad574e897d6cd0e5912928b211b307b20b6837c1bcbfaf640",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "81cd02a0ce17b263fd4cecbf886d760d6a2076e1dd0a277a0724c410c8ff8427",
+                "checksum": "5ba15d9836b0db556a55919b32995a2c10eaf9433050ae4a1d0bd2baf8ce70fb",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux": {
             "static": {
-                "checksum": "439699aa4762942764384575ff8b9b1b14133a49b2d83600b03e75bbeccf83a7",
+                "checksum": "a597e674a8285871df3c42dc98400a8adff969737d23f8336b10d68a5d70081b",
                 "filename": "appsignal-x86_64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "9751cef5e8d607bfa76bedbf0d8bed10fdfdcd285ba0daaa61fdc30534fdbaa4",
+                "checksum": "b07785881c68016ac037f81ce577e800ac809333bad03e0d53229e81ac9a5dda",
                 "filename": "appsignal-x86_64-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux-musl": {
             "static": {
-                "checksum": "91106eeca644d046e8f19372776dcc595c98c2aa5e9429de080bdc90c459e9ad",
+                "checksum": "ce8e4aa510880f533f17d62c53386ddf8222d2e5cd325b29f53c68661e76eea3",
                 "filename": "appsignal-x86_64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "f6b8283c8976de96892cce5e55bcda5aee95937e3593452b73dc5e4ce7ea1536",
+                "checksum": "e8a1c627b02a955f3f86ac4a24fc8ec23d0f88f6228f5415c468d18ca29268e5",
                 "filename": "appsignal-x86_64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux-musl": {
             "static": {
-                "checksum": "a095fb9a1747919093f5afaa3898da721b7c45a54f6b5d54ab2ac2d17c15025f",
+                "checksum": "2923da7c60ffc78f22c583e4653d904c11254c2ddd030face089b5e22e15ede2",
                 "filename": "appsignal-aarch64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "2623a9e2f4311fcaba8d4a5dde86e9e743b8059f801c1a28cefcea3273e8685e",
+                "checksum": "53277ba0f7fcc110c685964ace8605f83c828c626c5124febca377f667a6c2c0",
                 "filename": "appsignal-aarch64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "x86_64-freebsd": {
             "static": {
-                "checksum": "2cf7c6c961b0745c6b700472e16f86c89cb53163e5624d7dfbe9fa4c8641e9a2",
+                "checksum": "59d341ed55ae705f034fbfa0007488e2e4c92c8e8ce0cc20604e467f252c9fd1",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "7c2a270e8d6d7582b5cef25ffaabdcc36077bbf3b295997ae1f1b33968a39fe8",
+                "checksum": "0e68eb5bee50577a7c163d4bbe9d8e80732add069dacf0fdd6f76ab40846fea6",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },
         "amd64-freebsd": {
             "static": {
-                "checksum": "2cf7c6c961b0745c6b700472e16f86c89cb53163e5624d7dfbe9fa4c8641e9a2",
+                "checksum": "59d341ed55ae705f034fbfa0007488e2e4c92c8e8ce0cc20604e467f252c9fd1",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "7c2a270e8d6d7582b5cef25ffaabdcc36077bbf3b295997ae1f1b33968a39fe8",
+                "checksum": "0e68eb5bee50577a7c163d4bbe9d8e80732add069dacf0fdd6f76ab40846fea6",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },


### PR DESCRIPTION
I've updated the agent to report the `running_in_container` field in the agent's diagnose report's `host` sub report.

In the Python package I've copied it to the host sub report on the main diagnose report as well. That way the diagnose viewer has to less about where this field is originates from for every integration. It will report this field for the agent report, as for all other integrations, but that won't get in the way. We can even hide it in the viewer.

Part of https://github.com/appsignal/appsignal-python/issues/172

⚠️ Requires agent update in https://github.com/appsignal/appsignal-agent/pull/1073 to make the build pass.