### PR TITLE
Fix demo CLIs samples metadata

### DIFF
--- a/.changesets/fix-demo-samples-metadata.md
+++ b/.changesets/fix-demo-samples-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix the metadata on the demo CLI's example samples. It will no longer contain unused attributes. The performance sample will report a named `process_request.http` event, rather than report an `unknown` event, in the event timeline.

--- a/src/appsignal/cli/demo.py
+++ b/src/appsignal/cli/demo.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import time
 from argparse import ArgumentParser
 
 from opentelemetry import trace
 
 from ..client import Client, InvalidClientFileError
-from ..tracing import set_error, set_params, set_tag
+from ..tracing import set_category, set_error, set_params, set_tag
 from .command import AppsignalCLICommand
 
 
@@ -72,17 +73,13 @@ class Demo:
 
         # Performance sample
         with tracer.start_as_current_span("GET /demo") as span:
-            span.set_attribute("http.method", "GET")
+            set_category("process_request.http")
             set_params({"GET": {"id": 1}, "POST": {}}, span)
-            span.set_attribute(
-                "otel.instrumentation_library.name",
-                "opentelemetry.instrumentation.wsgi",
-            )
             set_tag("demo_sample", True, span)
+            time.sleep(0.1)
 
         # Error sample
         with tracer.start_as_current_span("GET /demo") as span:
-            span.set_attribute("http.method", "GET")
             set_params({"GET": {"id": 1}, "POST": {}}, span)
             set_tag("demo_sample", True, span)
             try:


### PR DESCRIPTION
Remove unused `http.method` attributes. They would appear in the "Attributes" box in the UI that only shows up for root span attributes we don't know what to do with.

Set the category for the performance sample so the event timeline doesn't show an "unknown" event.

Removing the `otel.instrumentation_library.name` attribute because it's not needed. It will use the root span's "GET /demo" name by default.

Fixes #168