### PR TITLE
Fix missing platform file error

### DIFF
--- a/.changesets/fix-crash-diagnose-report-platform.md
+++ b/.changesets/fix-crash-diagnose-report-platform.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix a crash on the diagnose report when attempting to report the platform for which AppSignal for Python was installed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ sources = ["src"]
 exclude = ["src/scripts", "tests", "conftest.py"]
 artifacts = [
   "src/appsignal/appsignal-agent",
+  "src/appsignal/_appsignal_platform",
   "src/appsignal/resources/cacert.pem",
   "src/appsignal/py.typed",
 ]

--- a/src/appsignal/agent.py
+++ b/src/appsignal/agent.py
@@ -41,9 +41,12 @@ class Agent:
             [self.agent_path, "--version"], capture_output=True
         ).stdout.split()[-1]
 
-    def architecutre_and_platform(self) -> list[str]:
-        with open(self.platform_path) as file:
-            return file.read().split("-", 1)
+    def architecture_and_platform(self) -> list[str]:
+        try:
+            with open(self.platform_path) as file:
+                return file.read().split("-", 1)
+        except FileNotFoundError:
+            return ["", ""]
 
 
 agent = Agent()

--- a/src/appsignal/cli/diagnose.py
+++ b/src/appsignal/cli/diagnose.py
@@ -189,7 +189,7 @@ class DiagnoseCommand(AppsignalCLICommand):
         self.agent_report = AgentReport(agent_json)
         self.paths_report = PathsReport(self.config)
 
-        package_arch, package_platform = agent.architecutre_and_platform()
+        package_arch, package_platform = agent.architecture_and_platform()
 
         self.report = {
             "agent": {

--- a/src/scripts/build_hook.py
+++ b/src/scripts/build_hook.py
@@ -45,11 +45,14 @@ def rm(path: str) -> None:
         pass
 
 
-def should_download(agent_path: str, version_path: str) -> bool:
+def should_download(agent_path: str, version_path: str, platform_path: str) -> bool:
     if not os.path.exists(agent_path):
         return True
 
     if not os.path.exists(version_path):
+        return True
+
+    if not os.path.exists(platform_path):
         return True
 
     with open(version_path) as version:
@@ -133,7 +136,7 @@ class CustomBuildHook(BuildHookInterface):
                 exit(1)
 
             print(f"Using custom agent binary at {tempagent_path}")
-        elif should_download(tempagent_path, tempversion_path):
+        elif should_download(tempagent_path, tempversion_path, tempplatform_path):
             temptar_path = os.path.join(tempdir_path, triple_filename(triple))
 
             rm(tempagent_path)


### PR DESCRIPTION
Intercom conversation: https://app.intercom.com/a/inbox/yzor8gyw/inbox/shared/all/conversation/16410700274092#part_id=comment-16410700274092-21909541622

The platform file should never be missing. But if it somehow is, then don't crash the diagnose report because of it.

Fix a typo in the name of the function that reads from the platform file.

If the platform file is missing from our agent build cache, make sure that we do not consider that to be a correct build. Downloading the agent again is overkill, but it does the trick.

Ensure the platform file is actually added by declaring it as a build artifact.