### PR TITLE
Remove sudo from CI install command for hatch

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -20,12 +20,12 @@ blocks:
       commands:
       - "sem-version python 3.11"
       - "pip install hatch"
-      - "hatch run lint:style"
+      - "hatch -v run lint:style"
     - name: Typing
       commands:
       - "sem-version python 3.11"
       - "pip install hatch"
-      - "hatch run lint:typing"
+      - "hatch -v run lint:typing"
     - name: Git Lint (Lintje)
       commands:
       - script/lint_git
@@ -47,19 +47,19 @@ blocks:
       commands:
       - "sem-version python 3.8"
       - "pip install hatch"
-      - "hatch run test.py38:pytest"
+      - "hatch -v run test.py38:pytest"
     - name: Python 3.9
       commands:
       - "sem-version python 3.9"
       - "pip install hatch"
-      - "hatch run test.py39:pytest"
+      - "hatch -v run test.py39:pytest"
     - name: Python 3.10
       commands:
       - "sem-version python 3.10"
       - "pip install hatch"
-      - "hatch run test.py310:pytest"
+      - "hatch -v run test.py310:pytest"
     - name: Python 3.11
       commands:
       - "sem-version python 3.11"
       - "pip install hatch"
-      - "hatch run test.py311:pytest"
+      - "hatch -v run test.py311:pytest"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,8 +11,6 @@ global_job_config:
   prologue:
     commands:
     - checkout
-    - "sem-version python 3.11"
-    - "sudo pip install hatch"
 blocks:
 - name: Linters
   dependencies: []
@@ -20,9 +18,13 @@ blocks:
     jobs:
     - name: Style
       commands:
+      - "sem-version python 3.11"
+      - "pip install hatch"
       - "hatch run lint:style"
     - name: Typing
       commands:
+      - "sem-version python 3.11"
+      - "pip install hatch"
       - "hatch run lint:typing"
     - name: Git Lint (Lintje)
       commands:
@@ -37,22 +39,27 @@ blocks:
           value: python
       commands:
         - "sem-version python 3.11"
+        - "pip install hatch"
         - git submodule init
         - git submodule update
         - ./tests/diagnose/bin/test
     - name: Python 3.8
       commands:
       - "sem-version python 3.8"
+      - "pip install hatch"
       - "hatch run test.py38:pytest"
     - name: Python 3.9
       commands:
       - "sem-version python 3.9"
+      - "pip install hatch"
       - "hatch run test.py39:pytest"
     - name: Python 3.10
       commands:
       - "sem-version python 3.10"
+      - "pip install hatch"
       - "hatch run test.py310:pytest"
     - name: Python 3.11
       commands:
       - "sem-version python 3.11"
+      - "pip install hatch"
       - "hatch run test.py311:pytest"


### PR DESCRIPTION
## Remove sudo from CI install command for hatch

Not sure why we were installing it with `sudo` but that broke the `sem-version python 3.11` setting, and ran the linter under Python 3.8 (the system default) instead.

Remove `sudo` from the command so the linter runs in the Python version we configure.

Because some jobs override the Python version set in the global prologue, move it to each individual job to avoid confusion.

## Print dependency versions installed in CI

Amend the CI config to print the versions of the dependencies that are installed when the Hatch env is initialised.


[skip changeset]