### PR TITLE
Skip Git linter on scheduled event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
   lint-git:
     name: "Git linter (Lintje)"
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'schedule' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
There's a bug or something on the scheduled build, so skip it for now.

Following the docs:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsif

[skip review]
[skip changeset]