### PR TITLE
Bump agent to version 0.31.2

### DIFF
--- a/.changesets/improve-missing-extractor-logs.md
+++ b/.changesets/improve-missing-extractor-logs.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Make the debug log message for OpenTelemetry spans from libraries we don't automatically recognize more clear. Mention the span id and the instrumentation library.

--- a/.changesets/remove-deprecated-extension-functions.md
+++ b/.changesets/remove-deprecated-extension-functions.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "remove"
+---
+
+Remove the `appsignal_set_host_guage` and `appsignal_set_process_gauge` extension functions. These functions were already deprecated and did not report any metrics.

--- a/.changesets/remove-deprecated-extension-functions.md
+++ b/.changesets/remove-deprecated-extension-functions.md
@@ -1,6 +1,0 @@
----
-bump: "patch"
-type: "remove"
----
-
-Remove the `appsignal_set_host_guage` and `appsignal_set_process_gauge` extension functions. These functions were already deprecated and did not report any metrics.

--- a/.changesets/update-probes-0.5.4.md
+++ b/.changesets/update-probes-0.5.4.md
@@ -1,6 +1,0 @@
----
-bump: "patch"
-type: "change"
----
-
-Fix disk usage returning a Vec with no entries on Alpine Linux when the `df --local` command fails.

--- a/.changesets/update-probes-0.5.4.md
+++ b/.changesets/update-probes-0.5.4.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Fix disk usage returning a Vec with no entries on Alpine Linux when the `df --local` command fails.

--- a/.changesets/update-sql_lexer-0.9.6.md
+++ b/.changesets/update-sql_lexer-0.9.6.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Fix an issue where queries containing a MySQL leading type indicator would only be partially sanitised.
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,29 @@ jobs:
       - name: "Run tests"
         run: "hatch -v run test.py$(echo ${{ matrix.python-version }} | tr -d '.'):pytest"
 
+  diagnose-test:
+    name: "Diagnose tests"
+    runs-on: ubuntu-latest
+    env:
+      LANGUAGE: python
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - name: "Install hatch"
+        run: "pip install hatch"
+      - name: "Init Git submodules"
+        run: "git submodule init"
+      - name: "Update Git submodules"
+        run: "git submodule update"
+      - name: "Run diagnose tests"
+        run: "./tests/diagnose/bin/test"
+
   lint-style:
     name: "Style linter"
     runs-on: ubuntu-latest

--- a/src/appsignal/agent.py
+++ b/src/appsignal/agent.py
@@ -39,7 +39,7 @@ class Agent:
     def version(self) -> bytes:
         return subprocess.run(
             [self.agent_path, "--version"], capture_output=True
-        ).stdout.split()[-1]
+        ).stdout.split()[1]
 
     def architecture_and_platform(self) -> list[str]:
         try:

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -111,9 +111,9 @@ def start_opentelemetry(config: Config) -> None:
     # Configure OpenTelemetry request headers config
     request_headers = list_to_env_str(config.option("request_headers"))
     if request_headers:
-        os.environ[
-            "OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST"
-        ] = request_headers
+        os.environ["OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST"] = (
+            request_headers
+        )
 
     opentelemetry_port = config.option("opentelemetry_port")
     _start_opentelemetry_tracer(opentelemetry_port)

--- a/src/scripts/agent.py
+++ b/src/scripts/agent.py
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-    "version": "bfe19b1",
+    "version": "0.31.2",
     "mirrors": [
         "https://appsignal-agent-releases.global.ssl.fastly.net",
         "https://d135dj0rjqvssy.cloudfront.net",
@@ -12,131 +12,131 @@ APPSIGNAL_AGENT_CONFIG = {
     "triples": {
         "x86_64-darwin": {
             "static": {
-                "checksum": "0985697683dc7f2bc0a353b637e3923a79b1945f730deceba73f65807cdcbb16",
+                "checksum": "42cdf814a89e5d6bd6e5cd9ba84103df82b43418012bb4f9251e98d0c3627759",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "ffa15b479a03b31a218d88fd0d381d93bd515073bf1e665a5ed6d6147e5f460f",
+                "checksum": "7497d64b125849d306ebca71a2a2ce83e3f76dbfbc809b43b5948e12b7351b96",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "universal-darwin": {
             "static": {
-                "checksum": "0985697683dc7f2bc0a353b637e3923a79b1945f730deceba73f65807cdcbb16",
+                "checksum": "42cdf814a89e5d6bd6e5cd9ba84103df82b43418012bb4f9251e98d0c3627759",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "ffa15b479a03b31a218d88fd0d381d93bd515073bf1e665a5ed6d6147e5f460f",
+                "checksum": "7497d64b125849d306ebca71a2a2ce83e3f76dbfbc809b43b5948e12b7351b96",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-darwin": {
             "static": {
-                "checksum": "8fe7adac3f265d47f9bff244b357b11551065c15542e22c5e5a10afa7d3d18f9",
+                "checksum": "8db9e31e090e767b1157d969521967f322be9dd73eb1b677b6192eb4c987af72",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "336918dfa41a4252b7a2cf8250013ee210a45def3d5893eb58ca6bba71c25320",
+                "checksum": "612d68620836b324bc61d8d4fd42630e50641116688ac78f2a7c806e2ee10ad1",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm64-darwin": {
             "static": {
-                "checksum": "8fe7adac3f265d47f9bff244b357b11551065c15542e22c5e5a10afa7d3d18f9",
+                "checksum": "8db9e31e090e767b1157d969521967f322be9dd73eb1b677b6192eb4c987af72",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "336918dfa41a4252b7a2cf8250013ee210a45def3d5893eb58ca6bba71c25320",
+                "checksum": "612d68620836b324bc61d8d4fd42630e50641116688ac78f2a7c806e2ee10ad1",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm-darwin": {
             "static": {
-                "checksum": "8fe7adac3f265d47f9bff244b357b11551065c15542e22c5e5a10afa7d3d18f9",
+                "checksum": "8db9e31e090e767b1157d969521967f322be9dd73eb1b677b6192eb4c987af72",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "336918dfa41a4252b7a2cf8250013ee210a45def3d5893eb58ca6bba71c25320",
+                "checksum": "612d68620836b324bc61d8d4fd42630e50641116688ac78f2a7c806e2ee10ad1",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux": {
             "static": {
-                "checksum": "8278a46232ab0b88dfbd5276a7253f147a950ea0f55ebb104ef825a528d24b73",
+                "checksum": "72873d1c7ad2d4d744fe3dd4370fb07b4c9d8a4f4d87febb8dbe08c532eebff8",
                 "filename": "appsignal-aarch64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "43f737a65dae52bc2118fcb1ba0fcf35774eb5e62a1d74c0e9d3f9713c1ff1ca",
+                "checksum": "b1510e425a0719cc7e7fe08e760c4794ece81108647ef73babffbb1eec93b5c7",
                 "filename": "appsignal-aarch64-linux-all-dynamic.tar.gz",
             },
         },
         "i686-linux": {
             "static": {
-                "checksum": "2b0cfc65ccd05d1258719e73fc19323729100d02a33d936ba79bb12cdede3763",
+                "checksum": "8779fdd2f02b034463900456b5b65a92d3a9165b87ba896b01baded96729685a",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "7b163e29e6db10b21295bbdbc06c31a8158522a0a14bd4cbaf4d71a8ac432902",
+                "checksum": "be30f7ff817a048af9f133ffd0da5c408f50b38e75bb3f25e47cd3916d5e4fac",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86-linux": {
             "static": {
-                "checksum": "2b0cfc65ccd05d1258719e73fc19323729100d02a33d936ba79bb12cdede3763",
+                "checksum": "8779fdd2f02b034463900456b5b65a92d3a9165b87ba896b01baded96729685a",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "7b163e29e6db10b21295bbdbc06c31a8158522a0a14bd4cbaf4d71a8ac432902",
+                "checksum": "be30f7ff817a048af9f133ffd0da5c408f50b38e75bb3f25e47cd3916d5e4fac",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux": {
             "static": {
-                "checksum": "10bafbef6445ea1a37529b34fb103dd48e185f61f19f58f573377127d03f6a60",
+                "checksum": "36fc29655d13e4dfe7bcbe2c798bfc16d68194610ff354d43e977f3768f31458",
                 "filename": "appsignal-x86_64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "bc6a5ffea46fc3e440a580344340e5dd0274372aae34132957707be0c0dc0bd2",
+                "checksum": "d37e57f55f44ac88a2b803fc17942f60137fbfa819134388941d22f579518170",
                 "filename": "appsignal-x86_64-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux-musl": {
             "static": {
-                "checksum": "fba0b10a3dcac0854cd9d19773ab48649fc79a35261eacdfe28d6e70c267b98a",
+                "checksum": "59b6cef9797746da9d6717effc0892a2f2219767734a0e76f8b3d1578dc0d9e0",
                 "filename": "appsignal-x86_64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "50f1c3f9102adb666ec27ac4aaab27193bf8896d64e3b4a2ba94c042f04f1cb7",
+                "checksum": "703d657ee15b69563c000fe150e368a91a12c9b39f16976f23a4b191284204f3",
                 "filename": "appsignal-x86_64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux-musl": {
             "static": {
-                "checksum": "98e8aafa0f688b1f1a9c37daf9e9cc1e36edc7e0ad65f86d8402469d15b6a1d6",
+                "checksum": "ec3ab8fcc20d1f31df6003e2ca3dcf257abfeddd1b7912fa6189f1f6905a89ab",
                 "filename": "appsignal-aarch64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "55dfab323718bc731678ff1268c9fa2e78de37ab39fb8b46aa806bfd41df4212",
+                "checksum": "b7a00a09b7e10f500b54913feefd6a16873849324f0e8ec65b36c58bdc1901b0",
                 "filename": "appsignal-aarch64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "x86_64-freebsd": {
             "static": {
-                "checksum": "09ebc6406d81fdf81b2e76bef6c1344f34292e1b3727f7fc984c8df5c7698db5",
+                "checksum": "bd654d5c555f6006e4145d76e27f02c5d22b285f411675a520455d6db6c8e165",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "cdab19e2e6d5f6ad15f3d87f735cd867e7c54db0412c893c39de3521afd9b6d3",
+                "checksum": "b06445f38b7b8b3e47f407540fb24f196dbf0a84583a2ad7f25bbba750930108",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },
         "amd64-freebsd": {
             "static": {
-                "checksum": "09ebc6406d81fdf81b2e76bef6c1344f34292e1b3727f7fc984c8df5c7698db5",
+                "checksum": "bd654d5c555f6006e4145d76e27f02c5d22b285f411675a520455d6db6c8e165",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "cdab19e2e6d5f6ad15f3d87f735cd867e7c54db0412c893c39de3521afd9b6d3",
+                "checksum": "b06445f38b7b8b3e47f407540fb24f196dbf0a84583a2ad7f25bbba750930108",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },


### PR DESCRIPTION
## Bump agent to version 0.31.2

The agent update and changesets are updated automatically.

[skip review]

## Remove changesets present in previous release

I didn't clean up these files in the agent repo so they ended up here automatically this release. Remove them.

## Fix diagnose tests agent version matcher

Update to the new numbered version matcher.

## Add diagnose tests to CI

This was not transferred in the move to GitHub Actions as CI.

Fixes #189

## Update agent version fetcher

The `appsignal-agent --version` output has changed so update the thing that parses that to fetch the right position of the output.

## Fix style issue in OpenTelemetry module

I don't have this warning locally, so it's a version issue again, but I'm not going to figure that mess out now.

---

[skip review]