### PR TITLE
Add `add_distribution_value` method

### DIFF
--- a/.changesets/add-distribution-value-custom-metric-helper.md
+++ b/.changesets/add-distribution-value-custom-metric-helper.md
@@ -1,0 +1,19 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add distribution value custom metric helper. This can be used to add values to distributions in the same way as in our other integrations:
+
+```python
+# Import the AppSignal metric helper
+from appsignal import add_distribution_value
+
+# The first argument is a string, the second argument a number (int/float)
+# add_distribution_value(metric_name, value)
+add_distribution_value("memory_usage", 100)
+add_distribution_value("memory_usage", 110)
+
+# Will create a metric "memory_usage" with the mean field value 105
+# Will create a metric "memory_usage" with the count field value 2
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,16 +94,16 @@ dependencies = [
 ]
 
 [tool.hatch.envs.lint.scripts]
-typing = "mypy --enable-incomplete-feature=Unpack {args}"
+typing = "mypy {args}"
 style = [
-  "ruff {args:.}",
+  "ruff check {args:.}",
   "isort --check {args:.}",
   "black --check --diff {args:.}",
 ]
 fmt = [
   "isort {args:.}",
   "black {args:.}",
-  "ruff --fix {args:.}",
+  "ruff check --fix {args:.}",
 ]
 all = [
   "fmt",
@@ -114,6 +114,8 @@ all = [
 [tool.ruff]
 line-length = 90
 extend-exclude = ["src/scripts/agent.py"]
+
+[tool.ruff.lint]
 select = [
   "E", "W", "F",  # flake8 (pycodestyle and pyflakes)
   "N",    # pep8-naming

--- a/src/appsignal/__init__.py
+++ b/src/appsignal/__init__.py
@@ -1,5 +1,5 @@
 from .client import Client as Appsignal
-from .metrics import increment_counter, set_gauge
+from .metrics import add_distribution_value, increment_counter, set_gauge
 from .tracing import (
     send_error,
     send_error_with_context,
@@ -36,6 +36,7 @@ __all__ = [
     "send_error_with_context",
     "increment_counter",
     "set_gauge",
+    "add_distribution_value",
 ]
 
 

--- a/src/appsignal/metrics.py
+++ b/src/appsignal/metrics.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Iterable
 
-from opentelemetry.metrics import CallbackOptions, Observation, UpDownCounter, get_meter
+from opentelemetry.metrics import (
+    CallbackOptions,
+    Histogram,
+    Observation,
+    UpDownCounter,
+    get_meter,
+)
 
 
 if TYPE_CHECKING:
@@ -21,6 +27,19 @@ def increment_counter(name: str, value: int | float, tags: Tags = None) -> None:
         _counters[name] = counter
 
     counter.add(value, tags)
+
+
+_histograms: dict[str, Histogram] = {}
+
+
+def add_distribution_value(name: str, value: int | float, tags: Tags = None) -> None:
+    if name in _histograms:
+        histogram = _histograms[name]
+    else:
+        histogram = _meter.create_histogram(name)
+        _histograms[name] = histogram
+
+    histogram.record(value, tags)
 
 
 _gauges: dict[str, dict[TagsKey, int | float]] = {}

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -112,9 +112,9 @@ def start_opentelemetry(config: Config) -> None:
     # Configure OpenTelemetry request headers config
     request_headers = list_to_env_str(config.option("request_headers"))
     if request_headers:
-        os.environ[
-            "OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST"
-        ] = request_headers
+        os.environ["OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST"] = (
+            request_headers
+        )
 
     opentelemetry_port = config.option("opentelemetry_port")
     _start_opentelemetry_tracer(opentelemetry_port)

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -14,6 +14,7 @@ from opentelemetry.sdk.metrics import (
     ObservableGauge,
     ObservableUpDownCounter,
     UpDownCounter,
+    Histogram,
 )
 from opentelemetry.sdk.metrics.export import (
     AggregationTemporality,
@@ -138,6 +139,7 @@ METRICS_PREFERRED_TEMPORALITY: dict[type, AggregationTemporality] = {
     ObservableCounter: AggregationTemporality.DELTA,
     ObservableGauge: AggregationTemporality.CUMULATIVE,
     ObservableUpDownCounter: AggregationTemporality.DELTA,
+    Histogram: AggregationTemporality.DELTA
 }
 
 


### PR DESCRIPTION
Add an `add_distribution_value` custom instrumentation metrics method, in the same line as the ones that currently exist for Ruby, Elixir and Node.js.

To do
---

- [x] Add to test setup -- https://github.com/appsignal/test-setups/pull/188
- [x] Write docs for it -- https://github.com/appsignal/appsignal-docs/pull/1805
- [x] Add a changeset