### PR TITLE
Implement minutely probes

### DIFF
--- a/.changesets/add-minutely-probes-system.md
+++ b/.changesets/add-minutely-probes-system.md
@@ -1,0 +1,20 @@
+---
+bump: "minor"
+type: "add"
+---
+
+Add a minutely probes system. This can be used, alongside our metric helpers, to report metrics to AppSignal once per minute.
+
+```python
+from appsignal import probes, set_gauge
+
+def new_carts(previous_carts=None):
+    current_carts = Cart.objects.all().count()
+
+    if previous_carts is not None:
+      set_gauge("new_carts", current_carts - previous_carts)
+
+    return current_carts
+
+probes.register("new_carts", new_carts)
+```

--- a/.changesets/add-minutely-probes-system.md
+++ b/.changesets/add-minutely-probes-system.md
@@ -18,3 +18,5 @@ def new_carts(previous_carts=None):
 
 probes.register("new_carts", new_carts)
 ```
+
+The minutely probes system starts by default, but no probes are automatically registered. You can use the `enable_minutely_probes` configuration option to disable it.

--- a/conftest.py
+++ b/conftest.py
@@ -21,8 +21,8 @@ from appsignal.opentelemetry import METRICS_PREFERRED_TEMPORALITY
 
 @pytest.fixture(scope="function", autouse=True)
 def disable_start_opentelemetry(mocker):
-    mocker.patch("appsignal.opentelemetry._start_opentelemetry_tracer")
-    mocker.patch("appsignal.opentelemetry._start_opentelemetry_metrics")
+    mocker.patch("appsignal.opentelemetry._start_tracer")
+    mocker.patch("appsignal.opentelemetry._start_metrics")
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/conftest.py
+++ b/conftest.py
@@ -87,6 +87,16 @@ def remove_logging_handlers_after_tests():
 
 
 @pytest.fixture(scope="function", autouse=True)
+def remove_probes_after_tests():
+    yield
+
+    from appsignal.probes import _probes, _probe_states
+
+    _probes.clear()
+    _probe_states.clear()
+
+
+@pytest.fixture(scope="function", autouse=True)
 def reset_agent_active_state():
     agent.active = False
 

--- a/conftest.py
+++ b/conftest.py
@@ -15,6 +15,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import set_tracer_provider
 
+from appsignal import probes
 from appsignal.agent import agent
 from appsignal.opentelemetry import METRICS_PREFERRED_TEMPORALITY
 
@@ -87,13 +88,11 @@ def remove_logging_handlers_after_tests():
 
 
 @pytest.fixture(scope="function", autouse=True)
-def remove_probes_after_tests():
+def stop_and_clear_probes_after_tests():
     yield
 
-    from appsignal.probes import _probes, _probe_states
-
-    _probes.clear()
-    _probe_states.clear()
+    probes.stop()
+    probes.clear()
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, ClassVar
 from .agent import agent
 from .config import Config, Options
 from .opentelemetry import start_opentelemetry
-from .probes import start_probes
+from .probes import start as start_probes
 
 
 if TYPE_CHECKING:
@@ -29,7 +29,7 @@ class Client:
 
     def __init__(self, **options: Unpack[Options]) -> None:
         self._config = Config(options)
-        self.start_logger()
+        self._start_logger()
 
         if not self._config.is_active():
             self._logger.info("AppSignal not starting: no active config found")
@@ -39,9 +39,13 @@ class Client:
             self._logger.info("Starting AppSignal")
             agent.start(self._config)
             start_opentelemetry(self._config)
+            self._start_probes()
+
+    def _start_probes(self) -> None:
+        if self._config.option("enable_minutely_probes"):
             start_probes()
 
-    def start_logger(self) -> None:
+    def _start_logger(self) -> None:
         self._logger = logging.getLogger("appsignal")
         self._logger.setLevel(self.LOG_LEVELS[self._config.option("log_level")])
 

--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, ClassVar
 from .agent import agent
 from .config import Config, Options
 from .opentelemetry import start_opentelemetry
+from .probes import start_probes
 
 
 if TYPE_CHECKING:
@@ -38,6 +39,7 @@ class Client:
             self._logger.info("Starting AppSignal")
             agent.start(self._config)
             start_opentelemetry(self._config)
+            start_probes()
 
     def start_logger(self) -> None:
         self._logger = logging.getLogger("appsignal")

--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from .agent import agent
 from .config import Config, Options
-from .opentelemetry import start_opentelemetry
+from .opentelemetry import start as start_opentelemetry
 from .probes import start as start_probes
 
 

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -32,6 +32,7 @@ class Options(TypedDict, total=False):
     )
     dns_servers: list[str] | None
     enable_host_metrics: bool | None
+    enable_minutely_probes: bool | None
     enable_nginx_metrics: bool | None
     enable_statsd: bool | None
     endpoint: str | None
@@ -80,6 +81,7 @@ class Config:
         ca_file_path=CA_FILE_PATH,
         diagnose_endpoint="https://appsignal.com/diag",
         enable_host_metrics=True,
+        enable_minutely_probes=True,
         enable_nginx_metrics=False,
         enable_statsd=False,
         environment=DEFAULT_ENVIRONMENT,
@@ -155,6 +157,9 @@ class Config:
             dns_servers=parse_list(os.environ.get("APPSIGNAL_DNS_SERVERS")),
             enable_host_metrics=parse_bool(
                 os.environ.get("APPSIGNAL_ENABLE_HOST_METRICS")
+            ),
+            enable_minutely_probes=parse_bool(
+                os.environ.get("APPSIGNAL_ENABLE_MINUTELY_PROBES")
             ),
             enable_nginx_metrics=parse_bool(
                 os.environ.get("APPSIGNAL_ENABLE_NGINX_METRICS")

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -108,7 +108,7 @@ DEFAULT_INSTRUMENTATION_ADDERS: Mapping[
 }
 
 
-def start_opentelemetry(config: Config) -> None:
+def start(config: Config) -> None:
     # Configure OpenTelemetry request headers config
     request_headers = list_to_env_str(config.option("request_headers"))
     if request_headers:
@@ -117,13 +117,13 @@ def start_opentelemetry(config: Config) -> None:
         )
 
     opentelemetry_port = config.option("opentelemetry_port")
-    _start_opentelemetry_tracer(opentelemetry_port)
-    _start_opentelemetry_metrics(opentelemetry_port)
+    _start_tracer(opentelemetry_port)
+    _start_metrics(opentelemetry_port)
 
     add_instrumentations(config)
 
 
-def _start_opentelemetry_tracer(opentelemetry_port: str | int) -> None:
+def _start_tracer(opentelemetry_port: str | int) -> None:
     otlp_exporter = OTLPSpanExporter(
         endpoint=f"http://localhost:{opentelemetry_port}/v1/traces"
     )
@@ -143,7 +143,7 @@ METRICS_PREFERRED_TEMPORALITY: dict[type, AggregationTemporality] = {
 }
 
 
-def _start_opentelemetry_metrics(opentelemetry_port: str | int) -> None:
+def _start_metrics(opentelemetry_port: str | int) -> None:
     metric_exporter = OTLPMetricExporter(
         endpoint=f"http://localhost:{opentelemetry_port}/v1/metrics",
         preferred_temporality=METRICS_PREFERRED_TEMPORALITY,

--- a/src/appsignal/probes.py
+++ b/src/appsignal/probes.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import logging
+from inspect import signature
+from threading import Thread
+from time import gmtime, sleep
+from typing import Any, Callable, NoReturn, Optional, TypeVar, Union, cast
+
+
+T = TypeVar("T")
+
+Probe = Union[Callable[[], None], Callable[[Optional[T]], Optional[T]]]
+
+_probes: dict[str, Probe] = {}
+_probe_states: dict[str, Any] = {}
+
+
+def start_probes() -> None:
+    Thread(target=_start_probes, daemon=True).start()
+
+
+def _start_probes() -> NoReturn:
+    sleep(_initial_wait_time())
+
+    while True:
+        _run_probes()
+        sleep(_wait_time())
+
+
+def _run_probes() -> None:
+    for name in _probes:
+        _run_probe(name)
+
+
+def _run_probe(name: str) -> None:
+    logger = logging.getLogger("appsignal")
+    logger.debug(f"Gathering minutely metrics with `{name}` probe")
+
+    try:
+        probe = _probes[name]
+
+        if len(signature(probe).parameters) > 0:
+            probe = cast(Callable[[Any], Any], probe)
+            state = _probe_states.get(name)
+            result = probe(state)
+            _probe_states[name] = result
+        else:
+            probe = cast(Callable[[], None], probe)
+            probe()
+
+    except Exception as e:
+        logger.debug(f"Error in minutely probe `{name}`: {e}")
+
+
+def _wait_time() -> int:
+    return 60 - gmtime().tm_sec
+
+
+def _initial_wait_time() -> int:
+    remaining_seconds = _wait_time()
+    if remaining_seconds > 30:
+        return remaining_seconds
+
+    return remaining_seconds + 60
+
+
+def register(name: str, probe: Probe) -> None:
+    if name in _probes:
+        logger = logging.getLogger("appsignal")
+        logger.debug(
+            f"A probe with the name `{name}` is already "
+            "registered. Overwriting the entry with the new probe."
+        )
+
+    _probes[name] = probe
+
+
+def unregister(name: str) -> None:
+    if name in _probes:
+        del _probes[name]
+    if name in _probe_states:
+        del _probe_states[name]

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1,6 +1,15 @@
+from time import sleep
 from typing import Any, Callable, cast
 
-from appsignal.probes import _probe_states, _probes, _run_probes, register, unregister
+from appsignal.probes import (
+    _probe_states,
+    _probes,
+    _run_probes,
+    register,
+    start,
+    stop,
+    unregister,
+)
 
 
 def test_register(mocker):
@@ -32,7 +41,7 @@ def test_register_with_state(mocker):
     probe.assert_called_with("state")
 
 
-def test_register_signatures(mocker):
+def test_register_signatures():
     # `mocker.Mock` is not used here because we want to test against
     # specific function signatures.
 
@@ -107,3 +116,23 @@ def test_unregister(mocker):
     assert "probe_name" not in _probes
     assert "probe_name" not in _probe_states
     probe.assert_called_once_with(None)
+
+
+def test_start_stop(mocker):
+    mocker.patch("appsignal.probes._initial_wait_time").return_value = 0.001
+    mocker.patch("appsignal.probes._wait_time").return_value = 0.001
+
+    probe = mocker.Mock()
+    register("probe_name", probe)
+    start()
+
+    sleep(0.05)
+
+    probe.assert_called()
+
+    stop()
+    call_count = probe.call_count
+
+    sleep(0.05)
+
+    assert probe.call_count == call_count

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1,0 +1,109 @@
+from typing import Any, Callable, cast
+
+from appsignal.probes import _probe_states, _probes, _run_probes, register, unregister
+
+
+def test_register(mocker):
+    probe = mocker.Mock()
+    register("probe_name", probe)
+
+    assert "probe_name" in _probes
+
+    _run_probes()
+
+    probe.assert_called_once()
+
+
+def test_register_with_state(mocker):
+    probe = mocker.Mock()
+    probe.return_value = "state"
+
+    register("probe_name", probe)
+
+    assert "probe_name" in _probes
+
+    _run_probes()
+
+    probe.assert_called_once_with(None)
+    assert _probe_states["probe_name"] == "state"
+
+    _run_probes()
+
+    probe.assert_called_with("state")
+
+
+def test_register_signatures(mocker):
+    # `mocker.Mock` is not used here because we want to test against
+    # specific function signatures.
+
+    no_args_called: Any = False
+    # An explicit "not called" string is used here because the first
+    # call to the probe will pass `None`.
+    one_arg_called_with: Any = "not called"
+    optional_arg_called_with: Any = "not called"
+    many_optional_args_called_with: Any = "not called"
+    too_many_args_called: Any = False
+
+    def no_args():
+        nonlocal no_args_called
+        no_args_called = True
+
+    def one_arg(state):
+        nonlocal one_arg_called_with
+        one_arg_called_with = state
+        return "state"
+
+    def optional_arg(state=None):
+        nonlocal optional_arg_called_with
+        optional_arg_called_with = state
+        return "state"
+
+    def many_optional_args(state, wut=None):
+        nonlocal many_optional_args_called_with
+        many_optional_args_called_with = state
+        return "state"
+
+    # Calling this should fail and log an error, but other probes should
+    # still run.
+    def too_many_args(state, wut):
+        nonlocal too_many_args_called
+        # This should not happen.
+        too_many_args_called = True
+
+    register("no_args", no_args)
+    register("one_arg", one_arg)
+    register("optional_arg", optional_arg)
+    register("many_optional_args", many_optional_args)
+    register("too_many_args", cast(Callable[[], None], too_many_args))
+
+    _run_probes()
+
+    assert no_args_called
+    assert one_arg_called_with is None
+    assert optional_arg_called_with is None
+    assert many_optional_args_called_with is None
+    assert not too_many_args_called
+
+    no_args_called = False
+    _run_probes()
+
+    assert no_args_called
+    assert one_arg_called_with == "state"
+    assert optional_arg_called_with == "state"
+    assert many_optional_args_called_with == "state"
+    assert not too_many_args_called
+
+
+def test_unregister(mocker):
+    probe = mocker.Mock()
+    probe.return_value = "state"
+
+    register("probe_name", probe)
+    _run_probes()
+
+    unregister("probe_name")
+    _run_probes()
+
+    assert "probe_name" not in _probes
+    assert "probe_name" not in _probe_states
+    probe.assert_called_once_with(None)


### PR DESCRIPTION
### [Implement minutely probes](https://github.com/appsignal/appsignal-python/pull/199/commits/0f484200ec174e7bccfc513fc0889b5f627a9484)

Implement a minutely probes system, heavily borrowing from the one
in our Ruby integration.

### [Implement enable_minutely_probes config option](https://github.com/appsignal/appsignal-python/pull/199/commits/521d97daffdb7d8e0cd0c3b03bd1e08e7826bfa3)

Implement a config option that globally enables or disables the
minutely probes system, in line with our other integrations.

When disabled by the config option, the minutely probes system can
still be manually enabled by calling `appsignal.probes.start()`.

Ensure that calling this function multiple times will not result in
the probes running multiple times per minute.

Add a lock around registering, unregistering and executing probes
to prevent race conditions where e.g. a probe's unregistering takes
place halfway through its execution.

### [Rename _opentelemetry functions](https://github.com/appsignal/appsignal-python/pull/199/commits/47f2a8d07e822ef65f3db6d40b1328bdd12742c0)

These functions are already in the `appsignal.opentelemetry` method,
they do not need to have `_opentelemetry` in their name.

### [Test start and stop methods](https://github.com/appsignal/appsignal-python/pull/199/commits/1e348c951e7420032bf9158ee28a91c2e69e17ef)

Got in a bit of a pickle to make the thread initialization testable.
When `client.start()` was called, a thread was spawned, so I had to
implement a way to stop these threads from executing during other
tests (hence `client.stop()`)

All other tests continue to call `_run_probes` directly because the
resulting behaviour is easier to reason about.

Fixes #129. See https://github.com/appsignal/test-setups/pull/189 for a test setup.