### PR TITLE
Modify installation instructions to use `import appsignal`

### DIFF
--- a/src/appsignal/cli/install.py
+++ b/src/appsignal/cli/install.py
@@ -23,6 +23,8 @@ appsignal = Appsignal(
 
 INSTALL_FILE_NAME = "__appsignal__.py"
 
+WARNING_EMOJI = "\u26A0\ufe0f"
+
 
 class InstallCommand(AppsignalCLICommand):
     """Generate Appsignal client integration code."""
@@ -123,9 +125,11 @@ class InstallCommand(AppsignalCLICommand):
             print()
             self._add_dependency("opentelemetry-instrumentation-django")
 
-        print("Django requires some manual configuration.")
-        print("The __appsignal__ module needs to be imported in the manage.py file")
-        print("and the appsignal.start() method needs to be called in the main method.")
+        print(f"{WARNING_EMOJI} Django requires some manual configuration.")
+        print(
+            "AppSignal needs to be imported and started at your Django application's "
+            "entry points."
+        )
         print()
         print("Please refer to the documentation for more information:")
         print("https://docs.appsignal.com/python/instrumentations/django.html")
@@ -139,9 +143,14 @@ class InstallCommand(AppsignalCLICommand):
             print()
             self._add_dependency("opentelemetry-instrumentation-flask")
 
-        print("Flask requires some manual configuration.")
-        print("The __appsignal__ module needs to be imported before Flask is imported")
-        print("and the appsignal.start() method needs to be called right after.")
+        print(f"{WARNING_EMOJI} Flask requires some manual configuration.")
+        print(
+            "AppSignal needs to be imported and initialized before Flask is imported."
+        )
+        print()
+        print("    import appsignal")
+        print("    appsignal.start()")
+        print("    import flask")
         print()
         print("Please refer to the documentation for more information:")
         print("https://docs.appsignal.com/python/instrumentations/flask.html")
@@ -149,10 +158,11 @@ class InstallCommand(AppsignalCLICommand):
     def _generic_installation(self) -> None:
         print("✅ Done! AppSignal for Python has now been installed.")
         print()
+        print(f"{WARNING_EMOJI} Some manual configuration might be required.")
         print("To start AppSignal in your application, add the following code to your")
         print("application's entrypoint:")
         print()
-        print("    from __appsignal__ import appsignal")
+        print("    import appsignal")
         print("    appsignal.start()")
         print()
         print("You can check a list of the supported integrations here:")


### PR DESCRIPTION
This is a sequel to #200 that I, uh, kinda forgot to do.

---

### [Modify installation instructions](https://github.com/appsignal/appsignal-python/commit/256b45578dd9b68e7f9a992fb9ae42a56635e799)

Add a warning emoji whenever manual instrumentation is required,
that is, always.

For Django's instructions, refer to the modification needed as a
generic "your entrypoints" and leave it for the docs to explain
further.

Change other instructions to use `import appsignal`, replacing the
use of `from __appsignal__ import appsignal`.

### [Specify requests dependency in hook](https://github.com/appsignal/appsignal-python/commit/7cf30c7354542362fac2959c1f67a85716782cad)

I am not sure exactly why this change is needed now. I think Hatch
[added support for specifying custom build hook dependencies][oops]
directly in the custom build hook in the last release, and this
might have accidentally broken the way in which we used to specify
this dependency.

It might also be that the breakage is intentional, in which case
they [forgot to update the docs][whoopsie].

[oops]: https://github.com/pypa/hatch/commit/c04877c183e850200231ed1501033a21db044d30
[whoopsie]: https://hatch.pypa.io/1.9/config/build/#dependencies_1