### PR TITLE
Bump agent and implement CPU count

### DIFF
--- a/.changesets/add-extractor-for-apollo-gateway.md
+++ b/.changesets/add-extractor-for-apollo-gateway.md
@@ -1,7 +1,0 @@
----
-bump: "minor"
-type: "add"
----
-
-Add Node.js Apollo Gateway span mapping. This supports reporting OpenTelemetry Apollo Gateway spans as AppSignal spans, for the Node.js integration.
-

--- a/.changesets/add-extractor-for-apollo-gateway.md
+++ b/.changesets/add-extractor-for-apollo-gateway.md
@@ -1,0 +1,7 @@
+---
+bump: "minor"
+type: "add"
+---
+
+Add Node.js Apollo Gateway span mapping. This supports reporting OpenTelemetry Apollo Gateway spans as AppSignal spans, for the Node.js integration.
+

--- a/.changesets/fix-asgi-events-showing-up-in-the--slow-api-requests--panel.md
+++ b/.changesets/fix-asgi-events-showing-up-in-the--slow-api-requests--panel.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix ASGI events (from Python ASGI applications) showing up in the "Slow API requests" panel.

--- a/.changesets/implement-cpu-count-configuration-option.md
+++ b/.changesets/implement-cpu-count-configuration-option.md
@@ -1,0 +1,10 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Implement CPU count configuration option. Use it to override the auto-detected, cgroups-provided number of CPUs that is used to calculate CPU usage percentages.
+
+To set it, use the `APPSIGNAL_CPU_COUNT` environment variable, the `cpu_count`
+configuration option in the Ruby, Elixir or Python integrations, the `cpuCount` attribute in the Node.js instrumentation, or the `cpu_count` configuration option in the stand-alone agent TOML configuration file.
+

--- a/.changesets/implement-cpu-count-configuration-option.md
+++ b/.changesets/implement-cpu-count-configuration-option.md
@@ -5,6 +5,4 @@ type: "add"
 
 Implement CPU count configuration option. Use it to override the auto-detected, cgroups-provided number of CPUs that is used to calculate CPU usage percentages.
 
-To set it, use the `APPSIGNAL_CPU_COUNT` environment variable, the `cpu_count`
-configuration option in the Ruby, Elixir or Python integrations, the `cpuCount` attribute in the Node.js instrumentation, or the `cpu_count` configuration option in the stand-alone agent TOML configuration file.
-
+To set it, use the the `cpu_count` configuration option or the `APPSIGNAL_CPU_COUNT` environment variable.

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -26,6 +26,7 @@ class Options(TypedDict, total=False):
     app_path: str | None
     bind_address: str | None
     ca_file_path: str | None
+    cpu_count: float | None
     diagnose_endpoint: str | None
     disable_default_instrumentations: None | (
         list[Config.DefaultInstrumentation] | bool
@@ -150,6 +151,7 @@ class Config:
             active=parse_bool(os.environ.get("APPSIGNAL_ACTIVE")),
             bind_address=os.environ.get("APPSIGNAL_BIND_ADDRESS"),
             ca_file_path=os.environ.get("APPSIGNAL_CA_FILE_PATH"),
+            cpu_count=parse_float(os.environ.get("APPSIGNAL_CPU_COUNT")),
             diagnose_endpoint=os.environ.get("APPSIGNAL_DIAGNOSE_ENDPOINT"),
             disable_default_instrumentations=parse_disable_default_instrumentations(
                 os.environ.get("APPSIGNAL_DISABLE_DEFAULT_INSTRUMENTATIONS")
@@ -220,6 +222,7 @@ class Config:
             "_APPSIGNAL_APP_PATH": options.get("app_path"),
             "_APPSIGNAL_BIND_ADDRESS": options.get("bind_address"),
             "_APPSIGNAL_CA_FILE_PATH": options.get("ca_file_path"),
+            "_APPSIGNAL_CPU_COUNT": float_to_env_str(options.get("cpu_count")),
             "_APPSIGNAL_DNS_SERVERS": list_to_env_str(options.get("dns_servers")),
             "_APPSIGNAL_DIAGNOSE_ENDPOINT": options.get("diagnose_endpoint"),
             "_APPSIGNAL_ENABLE_HOST_METRICS": bool_to_env_str(
@@ -328,6 +331,16 @@ def parse_list(value: str | None) -> list[str] | None:
     return value.split(",")
 
 
+def parse_float(value: str | None) -> float | None:
+    if value is None:
+        return None
+
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
 def parse_disable_default_instrumentations(
     value: str | None,
 ) -> list[Config.DefaultInstrumentation] | bool | None:
@@ -357,3 +370,10 @@ def list_to_env_str(value: list[str] | None) -> str | None:
         return None
 
     return ",".join(value)
+
+
+def float_to_env_str(value: float | None) -> str | None:
+    if value is None:
+        return None
+
+    return str(value)

--- a/src/scripts/agent.py
+++ b/src/scripts/agent.py
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-    "version": "0.33.2",
+    "version": "0.34.0",
     "mirrors": [
         "https://appsignal-agent-releases.global.ssl.fastly.net",
         "https://d135dj0rjqvssy.cloudfront.net",
@@ -12,131 +12,131 @@ APPSIGNAL_AGENT_CONFIG = {
     "triples": {
         "x86_64-darwin": {
             "static": {
-                "checksum": "0864691f001133fa479b34b00a682e76f374c40c161e7715756a3c036e3c8798",
+                "checksum": "a6c7f10f8efc09f007306189e8af7a2f5335ffec181f76677fa8548f12b8b774",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "5141528c4293e4bd619107ae79afc8e07fdc8b33835899c5cf3f82ab3d31de8f",
+                "checksum": "9d06361dee9ed2ea7fad29ce2bc11fafaafdc2dd9022217ccd1d3fb7ab0ec780",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "universal-darwin": {
             "static": {
-                "checksum": "0864691f001133fa479b34b00a682e76f374c40c161e7715756a3c036e3c8798",
+                "checksum": "a6c7f10f8efc09f007306189e8af7a2f5335ffec181f76677fa8548f12b8b774",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "5141528c4293e4bd619107ae79afc8e07fdc8b33835899c5cf3f82ab3d31de8f",
+                "checksum": "9d06361dee9ed2ea7fad29ce2bc11fafaafdc2dd9022217ccd1d3fb7ab0ec780",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-darwin": {
             "static": {
-                "checksum": "13506e5911523e7107a8cb714e18b3bcb690f3eeef88bf9aff54777ba540fdc4",
+                "checksum": "3c019c103d86b6d3a60d4da5fe5f9449d9980c6087d0f1494e24f91cd045d1d6",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "9d4deef17f42dc54981344a5af6b872e06dbd3d317be68b6abeb2403ffd65e23",
+                "checksum": "43e7f8a55d88d8245cce4ad47b3c4899aab344c023c8d3c2f7bbcf86987ce105",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm64-darwin": {
             "static": {
-                "checksum": "13506e5911523e7107a8cb714e18b3bcb690f3eeef88bf9aff54777ba540fdc4",
+                "checksum": "3c019c103d86b6d3a60d4da5fe5f9449d9980c6087d0f1494e24f91cd045d1d6",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "9d4deef17f42dc54981344a5af6b872e06dbd3d317be68b6abeb2403ffd65e23",
+                "checksum": "43e7f8a55d88d8245cce4ad47b3c4899aab344c023c8d3c2f7bbcf86987ce105",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm-darwin": {
             "static": {
-                "checksum": "13506e5911523e7107a8cb714e18b3bcb690f3eeef88bf9aff54777ba540fdc4",
+                "checksum": "3c019c103d86b6d3a60d4da5fe5f9449d9980c6087d0f1494e24f91cd045d1d6",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "9d4deef17f42dc54981344a5af6b872e06dbd3d317be68b6abeb2403ffd65e23",
+                "checksum": "43e7f8a55d88d8245cce4ad47b3c4899aab344c023c8d3c2f7bbcf86987ce105",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux": {
             "static": {
-                "checksum": "76702b5755d5bb45cc05df17dd38389b7e20e105a52324120a45ae1b481c7881",
+                "checksum": "6025983af8d38ba9265795f5b384bc78421f0641a93b749d8aa941881c818199",
                 "filename": "appsignal-aarch64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "bf518ce2cb4a9041fe819b6bf43e1bc793fe52b3e73527687d7812618c8e7407",
+                "checksum": "2530f59bdbdc5ea81d09b017d997b100b034824507d11359cddc21dea1a82cec",
                 "filename": "appsignal-aarch64-linux-all-dynamic.tar.gz",
             },
         },
         "i686-linux": {
             "static": {
-                "checksum": "22cbda11a8d801d75e9394033f5cf28f0ddcff66a2138720f827441bdcf919c2",
+                "checksum": "99556d16c59053cb79d1fa7b88a60cb6b2881daac9e9e5789546c9799bdef658",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "157492663e434421499f9cc0b510178387c8968e53bdc6e216db374b86d5c3dc",
+                "checksum": "18ad15a764b3d2a8d696c38806a28f699c83c6740449a723c17d8b6c66dad1e9",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86-linux": {
             "static": {
-                "checksum": "22cbda11a8d801d75e9394033f5cf28f0ddcff66a2138720f827441bdcf919c2",
+                "checksum": "99556d16c59053cb79d1fa7b88a60cb6b2881daac9e9e5789546c9799bdef658",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "157492663e434421499f9cc0b510178387c8968e53bdc6e216db374b86d5c3dc",
+                "checksum": "18ad15a764b3d2a8d696c38806a28f699c83c6740449a723c17d8b6c66dad1e9",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux": {
             "static": {
-                "checksum": "8ff0b1d7bf0cfc1c66e918545a9ab5c29be35c371cde48f64a01c725290599ed",
+                "checksum": "48ace6181571418a8e8236f8180345f8c97ac152953741b0c394019d0bbefb63",
                 "filename": "appsignal-x86_64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "a186c18536c3b7ec4802e852a62154cc976dcb5f554c3d0d8472d5cd7131b02b",
+                "checksum": "8277134ed0f9412af0ad74c40ac21a1d1003620d8135efadedd63a52eef6698c",
                 "filename": "appsignal-x86_64-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux-musl": {
             "static": {
-                "checksum": "a5e0af3e5e1ad908792e79c7c46b59119272e9836e5ea96791c78e3cb12ed132",
+                "checksum": "cb0b388ea1275f8b28547bf79bd127ceaba9b32027426f66eb45de8418a9592d",
                 "filename": "appsignal-x86_64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "17c108a83dff86b2531bf7f348481bb31ece53b4cc62615ca0a34332c0df2970",
+                "checksum": "8cb56f253f3958efd1d1cd874f444bddddf88dd07db4d3fe61f7c1f666dc3948",
                 "filename": "appsignal-x86_64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux-musl": {
             "static": {
-                "checksum": "92460560115d540a8140cbc360bd98beba8477e8a73eafd20ee611543b4528df",
+                "checksum": "571fc4749c22701a6e9e4c68d1fa9fcad0c443e62c6125c1ef57fb9735d93659",
                 "filename": "appsignal-aarch64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "d4749b10a1803080e0b1b0d8f95ef9d1fef0aa694fa0fc405df97812937d8e7c",
+                "checksum": "594b292d49a037c8670946bc3d50ecccb5ccc9fd5e5d9a722f1b474e571ad3c3",
                 "filename": "appsignal-aarch64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "x86_64-freebsd": {
             "static": {
-                "checksum": "8d8733c2adc0f750553be11b5e54fd614b13207be67863d95c57e4739021a92f",
+                "checksum": "5f47f08d1373a6d3e7ee579389a60780508b9a5ae6c69883c8a13a0ae6e09da7",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "8a9cbdc645b3833766458a252c2a8fefda76c62fceee8be795b286d65cc513c6",
+                "checksum": "a98fc71957d6d996baf83058a0614eb25b69f6b148675019dc78ffe1bf05cfe0",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },
         "amd64-freebsd": {
             "static": {
-                "checksum": "8d8733c2adc0f750553be11b5e54fd614b13207be67863d95c57e4739021a92f",
+                "checksum": "5f47f08d1373a6d3e7ee579389a60780508b9a5ae6c69883c8a13a0ae6e09da7",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "8a9cbdc645b3833766458a252c2a8fefda76c62fceee8be795b286d65cc513c6",
+                "checksum": "a98fc71957d6d996baf83058a0614eb25b69f6b148675019dc78ffe1bf05cfe0",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },

--- a/src/scripts/agent.py
+++ b/src/scripts/agent.py
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-    "version": "0.34.0",
+    "version": "0.34.1",
     "mirrors": [
         "https://appsignal-agent-releases.global.ssl.fastly.net",
         "https://d135dj0rjqvssy.cloudfront.net",
@@ -12,131 +12,131 @@ APPSIGNAL_AGENT_CONFIG = {
     "triples": {
         "x86_64-darwin": {
             "static": {
-                "checksum": "a6c7f10f8efc09f007306189e8af7a2f5335ffec181f76677fa8548f12b8b774",
+                "checksum": "351f3dae916d3e84177d8cc35eaeaca5345f4deca9e0925a29353915cc0530d2",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "9d06361dee9ed2ea7fad29ce2bc11fafaafdc2dd9022217ccd1d3fb7ab0ec780",
+                "checksum": "91ecacdf5e826dd21d5da26c07c5ecffd668cb16eaf15388d08a223425e716bb",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "universal-darwin": {
             "static": {
-                "checksum": "a6c7f10f8efc09f007306189e8af7a2f5335ffec181f76677fa8548f12b8b774",
+                "checksum": "351f3dae916d3e84177d8cc35eaeaca5345f4deca9e0925a29353915cc0530d2",
                 "filename": "appsignal-x86_64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "9d06361dee9ed2ea7fad29ce2bc11fafaafdc2dd9022217ccd1d3fb7ab0ec780",
+                "checksum": "91ecacdf5e826dd21d5da26c07c5ecffd668cb16eaf15388d08a223425e716bb",
                 "filename": "appsignal-x86_64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-darwin": {
             "static": {
-                "checksum": "3c019c103d86b6d3a60d4da5fe5f9449d9980c6087d0f1494e24f91cd045d1d6",
+                "checksum": "fd7359232fbd65f10ee565fcf65f4afa6d7a2ba1a8dead200c34736ca942df16",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "43e7f8a55d88d8245cce4ad47b3c4899aab344c023c8d3c2f7bbcf86987ce105",
+                "checksum": "a53ed8cc13d2821a4eee1ea7e4e58346125f27309973d4a2e8f059f129e927e2",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm64-darwin": {
             "static": {
-                "checksum": "3c019c103d86b6d3a60d4da5fe5f9449d9980c6087d0f1494e24f91cd045d1d6",
+                "checksum": "fd7359232fbd65f10ee565fcf65f4afa6d7a2ba1a8dead200c34736ca942df16",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "43e7f8a55d88d8245cce4ad47b3c4899aab344c023c8d3c2f7bbcf86987ce105",
+                "checksum": "a53ed8cc13d2821a4eee1ea7e4e58346125f27309973d4a2e8f059f129e927e2",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "arm-darwin": {
             "static": {
-                "checksum": "3c019c103d86b6d3a60d4da5fe5f9449d9980c6087d0f1494e24f91cd045d1d6",
+                "checksum": "fd7359232fbd65f10ee565fcf65f4afa6d7a2ba1a8dead200c34736ca942df16",
                 "filename": "appsignal-aarch64-darwin-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "43e7f8a55d88d8245cce4ad47b3c4899aab344c023c8d3c2f7bbcf86987ce105",
+                "checksum": "a53ed8cc13d2821a4eee1ea7e4e58346125f27309973d4a2e8f059f129e927e2",
                 "filename": "appsignal-aarch64-darwin-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux": {
             "static": {
-                "checksum": "6025983af8d38ba9265795f5b384bc78421f0641a93b749d8aa941881c818199",
+                "checksum": "dfbab18b7faa24684bf0ab57666b6b493356a3da43ecdba2e992b2d6d513cf31",
                 "filename": "appsignal-aarch64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "2530f59bdbdc5ea81d09b017d997b100b034824507d11359cddc21dea1a82cec",
+                "checksum": "865b8f034aa680aa6cdfe77cf117f071f9b5857c92cc7b6f36decfd5b2293b27",
                 "filename": "appsignal-aarch64-linux-all-dynamic.tar.gz",
             },
         },
         "i686-linux": {
             "static": {
-                "checksum": "99556d16c59053cb79d1fa7b88a60cb6b2881daac9e9e5789546c9799bdef658",
+                "checksum": "ce4a819f3eaa4590795497915e4a20b3fe281a0821364b80d26ffd1391af67a8",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "18ad15a764b3d2a8d696c38806a28f699c83c6740449a723c17d8b6c66dad1e9",
+                "checksum": "195d570b7f6b1ea5d2ced90dc12d68a6627e1886d078258b5483163e52afc620",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86-linux": {
             "static": {
-                "checksum": "99556d16c59053cb79d1fa7b88a60cb6b2881daac9e9e5789546c9799bdef658",
+                "checksum": "ce4a819f3eaa4590795497915e4a20b3fe281a0821364b80d26ffd1391af67a8",
                 "filename": "appsignal-i686-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "18ad15a764b3d2a8d696c38806a28f699c83c6740449a723c17d8b6c66dad1e9",
+                "checksum": "195d570b7f6b1ea5d2ced90dc12d68a6627e1886d078258b5483163e52afc620",
                 "filename": "appsignal-i686-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux": {
             "static": {
-                "checksum": "48ace6181571418a8e8236f8180345f8c97ac152953741b0c394019d0bbefb63",
+                "checksum": "e55f9ecb4e4b51e9232918216487712b63a7cfea9710763f61077e8d40d53dbe",
                 "filename": "appsignal-x86_64-linux-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "8277134ed0f9412af0ad74c40ac21a1d1003620d8135efadedd63a52eef6698c",
+                "checksum": "b5edf38f4ac2725907995518a1d09dc09c70cae600d1d3a287e0b6404c2301d2",
                 "filename": "appsignal-x86_64-linux-all-dynamic.tar.gz",
             },
         },
         "x86_64-linux-musl": {
             "static": {
-                "checksum": "cb0b388ea1275f8b28547bf79bd127ceaba9b32027426f66eb45de8418a9592d",
+                "checksum": "8963ebc98405648205a6d8aa371bafa49cb33cd104e0c3e6cc1856ba41fe3d8c",
                 "filename": "appsignal-x86_64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "8cb56f253f3958efd1d1cd874f444bddddf88dd07db4d3fe61f7c1f666dc3948",
+                "checksum": "6b5bab353f1597e64d0dc7638f02e8a0c4da2b341991f8e8efb251d8f94878a2",
                 "filename": "appsignal-x86_64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "aarch64-linux-musl": {
             "static": {
-                "checksum": "571fc4749c22701a6e9e4c68d1fa9fcad0c443e62c6125c1ef57fb9735d93659",
+                "checksum": "34bb72678b896a2a8289a97611a61a297b5a0e6110f5085a683ad93857cdf26c",
                 "filename": "appsignal-aarch64-linux-musl-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "594b292d49a037c8670946bc3d50ecccb5ccc9fd5e5d9a722f1b474e571ad3c3",
+                "checksum": "999e0bdc36613f9e016b01d4a00fab864b5996472e32ff1e03a0019877cd5e5d",
                 "filename": "appsignal-aarch64-linux-musl-all-dynamic.tar.gz",
             },
         },
         "x86_64-freebsd": {
             "static": {
-                "checksum": "5f47f08d1373a6d3e7ee579389a60780508b9a5ae6c69883c8a13a0ae6e09da7",
+                "checksum": "68e882ba3bc87328953d9bfbb676b00d4199756a7090d5cdc265a4b32d857cc5",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "a98fc71957d6d996baf83058a0614eb25b69f6b148675019dc78ffe1bf05cfe0",
+                "checksum": "3e770a387ada2e12052929c6f4ea141d05bd3dec5337ca53bbcf1078a6a2537d",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },
         "amd64-freebsd": {
             "static": {
-                "checksum": "5f47f08d1373a6d3e7ee579389a60780508b9a5ae6c69883c8a13a0ae6e09da7",
+                "checksum": "68e882ba3bc87328953d9bfbb676b00d4199756a7090d5cdc265a4b32d857cc5",
                 "filename": "appsignal-x86_64-freebsd-all-static.tar.gz",
             },
             "dynamic": {
-                "checksum": "a98fc71957d6d996baf83058a0614eb25b69f6b148675019dc78ffe1bf05cfe0",
+                "checksum": "3e770a387ada2e12052929c6f4ea141d05bd3dec5337ca53bbcf1078a6a2537d",
                 "filename": "appsignal-x86_64-freebsd-all-dynamic.tar.gz",
             },
         },

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,6 +48,7 @@ def test_environ_source():
     os.environ["APPSIGNAL_APP_NAME"] = "MyApp"
     os.environ["APPSIGNAL_BIND_ADDRESS"] = "0.0.0.0"
     os.environ["APPSIGNAL_CA_FILE_PATH"] = "/path/to/cacert.pem"
+    os.environ["APPSIGNAL_CPU_COUNT"] = "1.5"
     os.environ["APPSIGNAL_DNS_SERVERS"] = "8.8.8.8,8.8.4.4"
     os.environ["APPSIGNAL_ENABLE_HOST_METRICS"] = "true"
     os.environ["APPSIGNAL_ENABLE_NGINX_METRICS"] = "false"
@@ -81,6 +82,7 @@ def test_environ_source():
         active=True,
         bind_address="0.0.0.0",
         ca_file_path="/path/to/cacert.pem",
+        cpu_count=1.5,
         dns_servers=["8.8.8.8", "8.8.4.4"],
         enable_host_metrics=True,
         enable_nginx_metrics=False,
@@ -178,6 +180,7 @@ def test_set_private_environ():
             app_path="/path/to/app",
             bind_address="0.0.0.0",
             ca_file_path="/path/to/cacert.pem",
+            cpu_count=1.5,
             dns_servers=["8.8.8.8", "8.8.4.4"],
             enable_host_metrics=True,
             enable_nginx_metrics=False,
@@ -216,6 +219,7 @@ def test_set_private_environ():
     assert os.environ["_APPSIGNAL_APP_PATH"] == "/path/to/app"
     assert os.environ["_APPSIGNAL_BIND_ADDRESS"] == "0.0.0.0"
     assert os.environ["_APPSIGNAL_CA_FILE_PATH"] == "/path/to/cacert.pem"
+    assert os.environ["_APPSIGNAL_CPU_COUNT"] == "1.5"
     assert os.environ["_APPSIGNAL_DNS_SERVERS"] == "8.8.8.8,8.8.4.4"
     assert os.environ["_APPSIGNAL_ENABLE_HOST_METRICS"] == "true"
     assert os.environ["_APPSIGNAL_ENABLE_NGINX_METRICS"] == "false"


### PR DESCRIPTION
### [Bump agent to version 0.34.0](https://github.com/appsignal/appsignal-python/commit/c688ce1ae80decd0cdf1ba9d99d302b25082d95a)

The agent update and changesets are updated automatically.

### [Bump agent to version 0.34.1](https://github.com/appsignal/appsignal-python/commit/3a797e1cca59ba1d6fcd67f7e36c25eff0445ee2)

The agent update and changesets are updated automatically.

### [Remove irrelevant agent changesets](https://github.com/appsignal/appsignal-python/commit/4f867d0101fc08413e882b9f313f03f0ddad4a5c)

Remove changesets from the agent that are not relevant to the Python
integration.

### [Add cpu_count configuration option](https://github.com/appsignal/appsignal-python/commit/fd0dfe1f9e47cfc92649ff94760450355057ce1e)

Implement the `cpu_count` (`APPSIGNAL_CPU_COUNT` environment variable)
configuration option for the AppSignal for Python integration.