### PR TITLE
Internal logging improvements

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import os
 import platform
 import tempfile
@@ -18,6 +17,7 @@ from opentelemetry.trace import set_tracer_provider
 from appsignal import probes
 from appsignal.agent import agent
 from appsignal.client import _reset_client
+from appsignal.internal_logger import _reset_logger
 from appsignal.opentelemetry import METRICS_PREFERRED_TEMPORALITY
 
 
@@ -80,12 +80,10 @@ def reset_environment_between_tests():
 
 
 @pytest.fixture(scope="function", autouse=True)
-def remove_logging_handlers_after_tests():
+def reset_internal_logger_after_tests():
     yield
 
-    logger = logging.getLogger("appsignal")
-    for handler in logger.handlers:
-        logger.removeHandler(handler)
+    _reset_logger()
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import logging
-import sys
-from logging import DEBUG, ERROR, INFO, WARNING, Logger
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING
 
+from . import internal_logger as logger
 from .agent import agent
 from .config import Config, Options
 from .opentelemetry import start as start_opentelemetry
@@ -24,26 +22,13 @@ def _reset_client() -> None:
 
 
 class Client:
-    _logger: Logger
     _config: Config
-
-    LOG_LEVELS: ClassVar[dict[str, int]] = {
-        "error": ERROR,
-        "warning": WARNING,
-        "info": INFO,
-        "debug": DEBUG,
-        "trace": DEBUG,
-    }
 
     def __init__(self, **options: Unpack[Options]) -> None:
         global _client
 
         self._config = Config(options)
-        self._start_logger()
         _client = self
-
-        if not self._config.is_active():
-            self._logger.info("AppSignal not starting: no active config found")
 
     @classmethod
     def config(cls) -> Config | None:
@@ -54,43 +39,13 @@ class Client:
 
     def start(self) -> None:
         if self._config.is_active():
-            self._logger.info("Starting AppSignal")
+            logger.info("Starting AppSignal")
             agent.start(self._config)
             start_opentelemetry(self._config)
             self._start_probes()
+        else:
+            logger.info("AppSignal not starting: no active config found")
 
     def _start_probes(self) -> None:
         if self._config.option("enable_minutely_probes"):
             start_probes()
-
-    def _start_logger(self) -> None:
-        self._logger = logging.getLogger("appsignal")
-        self._logger.setLevel(self.LOG_LEVELS[self._config.option("log_level")])
-
-        if self._config.option("log") == "file":
-            log_file_path = self._config.log_file_path()
-            if log_file_path:
-                handler = logging.FileHandler(log_file_path)
-                handler.setFormatter(
-                    logging.Formatter(
-                        "[%(asctime)s (process) #%(process)d][%(levelname)s] "
-                        "%(message)s",
-                        "%Y-%m-%dT%H:%M:%S",
-                    )
-                )
-                self._logger.addHandler(handler)
-            else:
-                self._start_stdout_logger()
-        else:
-            self._start_stdout_logger()
-
-    def _start_stdout_logger(self) -> None:
-        handler = logging.StreamHandler(sys.stdout)
-        handler.setFormatter(
-            logging.Formatter(
-                "[%(asctime)s (process) #%(process)d][appsignal][%(levelname)s] "
-                "%(message)s",
-                "%Y-%m-%dT%H:%M:%S",
-            )
-        )
-        self._logger.addHandler(handler)

--- a/src/appsignal/heartbeat.py
+++ b/src/appsignal/heartbeat.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import logging
 from binascii import hexlify
 from os import urandom
 from time import time
 from typing import Any, Callable, Literal, TypedDict, TypeVar, Union
 
+from . import internal_logger as logger
 from .client import Client
 from .config import Config
 from .transmitter import transmit
@@ -36,7 +36,6 @@ class Heartbeat:
 
     def _transmit(self, event: Event) -> None:
         config = Client.config() or Config()
-        logger = logging.getLogger("appsignal")
 
         if not config.is_active():
             logger.debug("AppSignal not active, not transmitting heartbeat event")

--- a/src/appsignal/internal_logger.py
+++ b/src/appsignal/internal_logger.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import logging
+import sys
+
+
+_LOG_LEVEL_MAPPING: dict[str, int] = {
+    "error": logging.ERROR,
+    "warning": logging.WARNING,
+    "info": logging.INFO,
+    "debug": logging.DEBUG,
+    "trace": logging.DEBUG,
+}
+
+_logger: logging.Logger | None = None
+
+
+def _reset_logger() -> None:
+    logger = logging.getLogger("appsignal")
+    for handler in logger.handlers:
+        logger.removeHandler(handler)
+
+    global _logger
+    _logger = None
+
+
+def error(message: str) -> None:
+    _log("error", message)
+
+
+def warning(message: str) -> None:
+    _log("warning", message)
+
+
+def info(message: str) -> None:
+    _log("info", message)
+
+
+def debug(message: str) -> None:
+    _log("debug", message)
+
+
+def _log(level: str, message: str) -> None:
+    global _logger
+
+    if _logger is None:
+        _logger = _configure_logger()
+
+    _logger.log(_LOG_LEVEL_MAPPING[level], message)
+
+
+def _configure_logger() -> logging.Logger:
+    from .client import Client
+    from .config import Config
+
+    client_config = Client.config()
+    config = client_config or Config({})
+    level = config.option("log_level")
+
+    logger = logging.getLogger("appsignal")
+    logger.setLevel(_LOG_LEVEL_MAPPING[level])
+
+    if config.option("log") == "file":
+        log_file_path = config.log_file_path()
+        if log_file_path:
+            _configure_file_logger(logger, log_file_path)
+        else:
+            _configure_stdout_logger(logger)
+    else:
+        _configure_stdout_logger(logger)
+
+    if client_config is None:
+        logger.warning(
+            "Internal logger used before initializing the AppSignal client; "
+            "using default logger configuration."
+        )
+
+    return logger
+
+
+def _configure_file_logger(logger: logging.Logger, log_file_path: str) -> None:
+    handler = logging.FileHandler(log_file_path)
+    handler.setFormatter(
+        logging.Formatter(
+            "[%(asctime)s (process) #%(process)d][%(levelname)s] %(message)s",
+            "%Y-%m-%dT%H:%M:%S",
+        )
+    )
+
+    logger.addHandler(handler)
+
+
+def _configure_stdout_logger(logger: logging.Logger) -> None:
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(
+        logging.Formatter(
+            "[%(asctime)s (process) #%(process)d][appsignal][%(levelname)s] "
+            "%(message)s",
+            "%Y-%m-%dT%H:%M:%S",
+        )
+    )
+
+    logger.addHandler(handler)

--- a/src/appsignal/internal_logger.py
+++ b/src/appsignal/internal_logger.py
@@ -13,6 +13,7 @@ _LOG_LEVEL_MAPPING: dict[str, int] = {
 }
 
 _logger: logging.Logger | None = None
+_level: str | None = None
 
 
 def _reset_logger() -> None:
@@ -20,8 +21,8 @@ def _reset_logger() -> None:
     for handler in logger.handlers:
         logger.removeHandler(handler)
 
-    global _logger
-    _logger = None
+    global _logger, _level
+    _logger, _level = None, None
 
 
 def error(message: str) -> None:
@@ -40,16 +41,23 @@ def debug(message: str) -> None:
     _log("debug", message)
 
 
+def trace(message: str) -> None:
+    _log("trace", message)
+
+
 def _log(level: str, message: str) -> None:
-    global _logger
+    global _logger, _level
 
     if _logger is None:
-        _logger = _configure_logger()
+        _logger, _level = _configure_logger()
+
+    if level == "trace" and _level != "trace":
+        return
 
     _logger.log(_LOG_LEVEL_MAPPING[level], message)
 
 
-def _configure_logger() -> logging.Logger:
+def _configure_logger() -> tuple[logging.Logger, str]:
     from .client import Client
     from .config import Config
 
@@ -75,7 +83,7 @@ def _configure_logger() -> logging.Logger:
             "using default logger configuration."
         )
 
-    return logger
+    return logger, level
 
 
 def _configure_file_logger(logger: logging.Logger, log_file_path: str) -> None:

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import logging
+from . import internal_logger as logger
+
 import os
 from typing import TYPE_CHECKING, Callable, Mapping
 
@@ -163,7 +164,6 @@ def add_instrumentations(
         Config.DefaultInstrumentation, DefaultInstrumentationAdder
     ] = DEFAULT_INSTRUMENTATION_ADDERS,
 ) -> None:
-    logger = logging.getLogger("appsignal")
     disable_list = config.options.get("disable_default_instrumentations") or []
 
     if disable_list is True:

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from . import internal_logger as logger
-
 import os
 from typing import TYPE_CHECKING, Callable, Mapping
 
@@ -25,6 +23,7 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
+from . import internal_logger as logger
 from .config import Config, list_to_env_str
 
 

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -192,7 +192,7 @@ def add_instrumentations(
     for name, adder in _adders.items():
         if name not in disable_list:
             try:
-                logger.info(f"Instrumenting {name}")
                 adder()
+                logger.info(f"Instrumented {name}")
             except ModuleNotFoundError:
                 pass

--- a/src/appsignal/probes.py
+++ b/src/appsignal/probes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import logging
+from . import internal_logger as logger
 from inspect import signature
 from threading import Event, Lock, Thread
 from time import gmtime
@@ -43,7 +43,6 @@ def _run_probes() -> None:
 
 
 def _run_probe(name: str) -> None:
-    logger = logging.getLogger("appsignal")
     logger.debug(f"Gathering minutely metrics with `{name}` probe")
 
     try:
@@ -77,7 +76,6 @@ def _initial_wait_time() -> int:
 def register(name: str, probe: Probe) -> None:
     with _lock:
         if name in _probes:
-            logger = logging.getLogger("appsignal")
             logger.debug(
                 f"A probe with the name `{name}` is already "
                 "registered. Overwriting the entry with the new probe."

--- a/src/appsignal/probes.py
+++ b/src/appsignal/probes.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from . import internal_logger as logger
 from inspect import signature
 from threading import Event, Lock, Thread
 from time import gmtime
 from typing import Any, Callable, Optional, TypeVar, Union, cast
+
+from . import internal_logger as logger
 
 
 T = TypeVar("T")

--- a/src/appsignal/tracing.py
+++ b/src/appsignal/tracing.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import json
-from . import internal_logger as logger
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Iterator
 
 from opentelemetry import trace
 from opentelemetry.context import Context
 from opentelemetry.trace import Status, StatusCode
+
+from . import internal_logger as logger
 
 
 if TYPE_CHECKING:

--- a/src/appsignal/tracing.py
+++ b/src/appsignal/tracing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-import logging
+from . import internal_logger as logger
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Iterator
 
@@ -12,8 +12,6 @@ from opentelemetry.trace import Status, StatusCode
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span
-
-logger = logging.getLogger("appsignal")
 
 
 def _set_attribute(attribute: str, value: Any, span: Span | None = None) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import os
-import re
-from logging import DEBUG, ERROR, INFO, WARNING
 
 from appsignal.agent import agent
 from appsignal.client import Client
@@ -100,77 +98,3 @@ def test_client_inactive():
         os.environ.get("OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST")
         is None
     )
-
-
-def test_logger_default_level():
-    client = Client()
-    assert client._logger.getEffectiveLevel() == INFO
-
-    client = Client(log_level="info")
-    assert client._logger.getEffectiveLevel() == INFO
-
-
-def test_logger_error_level():
-    client = Client(log_level="error")
-    assert client._logger.getEffectiveLevel() == ERROR
-
-
-def test_logger_warning_level():
-    client = Client(log_level="warning")
-    assert client._logger.getEffectiveLevel() == WARNING
-
-
-def test_logger_debug_level():
-    client = Client(log_level="debug")
-    assert client._logger.getEffectiveLevel() == DEBUG
-
-
-def test_logger_trace_level():
-    client = Client(log_level="trace")
-    assert client._logger.getEffectiveLevel() == DEBUG
-
-
-def test_logger_file(tmp_path):
-    log_path = tmp_path
-    log_file_path = os.path.join(log_path, "appsignal.log")
-
-    client = Client(log_path=log_path)
-    logger = client._logger
-    logger.info("test me")
-
-    with open(log_file_path) as file:
-        contents = file.read()
-
-    log_line_regex = re.compile(
-        r"\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2} \(process\) #\d+\]\[INFO\] test me"
-    )
-    assert log_line_regex.search(contents)
-
-
-def test_logger_stdout(capsys):
-    client = Client(log="stdout")
-    logger = client._logger
-    logger.info("test me")
-
-    captured = capsys.readouterr()
-    log_line_regex = re.compile(
-        r"\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2} \(process\) #\d+\]\[appsignal\]"
-        r"\[INFO\] test me"
-    )
-    assert log_line_regex.search(captured.out)
-
-
-def test_logger_stdout_fallback(capsys, mocker):
-    # Make any path appear unwritable so it will fall back to the STDOUT logger
-    mocker.patch("os.access", return_value=False)
-
-    client = Client(log="file", log_path=None)
-    logger = client._logger
-    logger.info("test me")
-
-    captured = capsys.readouterr()
-    log_line_regex = re.compile(
-        r"\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2} \(process\) #\d+\]\[appsignal\]"
-        r"\[INFO\] test me"
-    )
-    assert log_line_regex.search(captured.out)

--- a/tests/test_internal_logger.py
+++ b/tests/test_internal_logger.py
@@ -8,44 +8,77 @@ from appsignal.client import Client
 
 def test_logger_default_level():
     internal_logger.info("trigger logger initialization")
+
     assert internal_logger._logger is not None
     assert internal_logger._logger.getEffectiveLevel() == INFO
+    assert internal_logger._level == "info"
 
 
 def test_logger_info_level():
     Client(log_level="info")
     internal_logger.info("trigger logger initialization")
+
     assert internal_logger._logger is not None
     assert internal_logger._logger.getEffectiveLevel() == INFO
+    assert internal_logger._level == "info"
 
 
 def test_logger_error_level():
     Client(log_level="error")
     internal_logger.info("trigger logger initialization")
+
     assert internal_logger._logger is not None
     assert internal_logger._logger.getEffectiveLevel() == ERROR
+    assert internal_logger._level == "error"
 
 
 def test_logger_warning_level():
     Client(log_level="warning")
-    internal_logger.info("ignore me")
+    internal_logger.info("trigger logger initialization")
+
     assert internal_logger._logger is not None
     assert internal_logger._logger.getEffectiveLevel() == WARNING
+    assert internal_logger._level == "warning"
 
 
 def test_logger_debug_level():
     Client(log_level="debug")
-    internal_logger.info("ignore me")
+    internal_logger.info("trigger logger initialization")
+
     assert internal_logger._logger is not None
     assert internal_logger._logger.getEffectiveLevel() == DEBUG
+    assert internal_logger._level == "debug"
 
 
 def test_logger_trace_level():
     Client(log_level="trace")
-    # the logger must be used for `_logger` to be initialised
-    internal_logger.info("ignore me")
+    internal_logger.info("trigger logger initialization")
+
     assert internal_logger._logger is not None
     assert internal_logger._logger.getEffectiveLevel() == DEBUG
+    assert internal_logger._level == "trace"
+
+
+def test_logger_trace_level_logs_trace(mocker):
+    Client(log_level="trace")
+    internal_logger.info("trigger logger initialization")
+
+    mock = mocker.patch("appsignal.internal_logger._logger.log")
+    internal_logger.trace("trace message")
+    mock.assert_called_with(DEBUG, "trace message")
+    internal_logger.debug("debug message")
+    mock.assert_called_with(DEBUG, "debug message")
+
+
+def test_logger_debug_level_does_not_log_trace(mocker):
+    Client(log_level="debug")
+    internal_logger.info("trigger logger initialization")
+
+    mock = mocker.patch("appsignal.internal_logger._logger.log")
+    internal_logger.trace("trace message")
+    mock.assert_not_called()
+    internal_logger.debug("debug message")
+    mock.assert_called_with(DEBUG, "debug message")
 
 
 def test_logger_file(tmp_path):

--- a/tests/test_internal_logger.py
+++ b/tests/test_internal_logger.py
@@ -1,0 +1,91 @@
+import os
+import re
+from logging import DEBUG, ERROR, INFO, WARNING
+
+from appsignal import internal_logger
+from appsignal.client import Client
+
+
+def test_logger_default_level():
+    internal_logger.info("trigger logger initialization")
+    assert internal_logger._logger is not None
+    assert internal_logger._logger.getEffectiveLevel() == INFO
+
+
+def test_logger_info_level():
+    Client(log_level="info")
+    internal_logger.info("trigger logger initialization")
+    assert internal_logger._logger is not None
+    assert internal_logger._logger.getEffectiveLevel() == INFO
+
+
+def test_logger_error_level():
+    Client(log_level="error")
+    internal_logger.info("trigger logger initialization")
+    assert internal_logger._logger is not None
+    assert internal_logger._logger.getEffectiveLevel() == ERROR
+
+
+def test_logger_warning_level():
+    Client(log_level="warning")
+    internal_logger.info("ignore me")
+    assert internal_logger._logger is not None
+    assert internal_logger._logger.getEffectiveLevel() == WARNING
+
+
+def test_logger_debug_level():
+    Client(log_level="debug")
+    internal_logger.info("ignore me")
+    assert internal_logger._logger is not None
+    assert internal_logger._logger.getEffectiveLevel() == DEBUG
+
+
+def test_logger_trace_level():
+    Client(log_level="trace")
+    # the logger must be used for `_logger` to be initialised
+    internal_logger.info("ignore me")
+    assert internal_logger._logger is not None
+    assert internal_logger._logger.getEffectiveLevel() == DEBUG
+
+
+def test_logger_file(tmp_path):
+    log_path = tmp_path
+    log_file_path = os.path.join(log_path, "appsignal.log")
+
+    Client(log_path=log_path)
+    internal_logger.info("test me")
+
+    with open(log_file_path) as file:
+        contents = file.read()
+
+    log_line_regex = re.compile(
+        r"\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2} \(process\) #\d+\]\[INFO\] test me"
+    )
+    assert log_line_regex.search(contents)
+
+
+def test_logger_stdout(capsys):
+    Client(log="stdout")
+    internal_logger.info("test me")
+
+    captured = capsys.readouterr()
+    log_line_regex = re.compile(
+        r"\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2} \(process\) #\d+\]\[appsignal\]"
+        r"\[INFO\] test me"
+    )
+    assert log_line_regex.search(captured.out)
+
+
+def test_logger_stdout_fallback(capsys, mocker):
+    # Make any path appear unwritable so it will fall back to the STDOUT logger
+    mocker.patch("os.access", return_value=False)
+
+    Client(log="file", log_path=None)
+    internal_logger.info("test me")
+
+    captured = capsys.readouterr()
+    log_line_regex = re.compile(
+        r"\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2} \(process\) #\d+\]\[appsignal\]"
+        r"\[INFO\] test me"
+    )
+    assert log_line_regex.search(captured.out)


### PR DESCRIPTION
Found myself needing to do some of this (the OpenTelemetry part, specifically, for the SQLAlchemy instrumentation) and wishing (earlier on, for the heartbeats and probes) that I did not have to initialise a logger instance in order to log something, and that a genuine trace-level logging option was available.

[skip changeset] because none of this really changes anything for customers (who should not be using `"trace"`)

### [Move internal logger to separate module](https://github.com/appsignal/appsignal-python/commit/66feadd1852a2327aae87d01306a50c428e8bc32)

The logger was kind of "bolted on" to the client class -- when other
parts of the code wanted to use it, they needed to fetch the logger
with the same name separately and deal with it as a variable.

Move this to a separate `internal_logger` module which is initialised
on-demand from the existing initialised (not necessarily started!)
global client.

### [Implement trace logging level](https://github.com/appsignal/appsignal-python/commit/9f2e8ab653019337943781f56c5d35005c5e6b06)

Make it possible to meaningfully log "trace" logging level messages
(meaning they're logged on trace log level, and not logged on debug
log level) like in our other integrations.

### [Log OpenTelemetry spans on trace](https://github.com/appsignal/appsignal-python/commit/f2c42180ff200b7085f53af974690a8059c7ffc6)

When logging level is set to "trace", log all OpenTelemetry spans to
the console.

This is similar to what the Node.js integration does with the
OpenTelemetry diagnostics, which does not seem to have a direct
equivalent in Python's OpenTelemetry implementation.

### [Log instrumentation only when successful](https://github.com/appsignal/appsignal-python/commit/72aab0555b4050f9989b152be9fe3c66243c2c40)

Do not log "Instrumenting ..." when attempting to start an
instrumentation (the required dependency for which might not actually
be installed)

Instead, log "Instrumented ..." when an instrumentation is correctly
started.