### PR TITLE
Add noop mode for unsupported systems

### DIFF
--- a/.changesets/add-noop-mode-for-unsupported-systems.md
+++ b/.changesets/add-noop-mode-for-unsupported-systems.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Unsupported systems, like Microsoft Windows, won't start the agent and other integration components to prevent them from failing and allowing apps to be run normally.

--- a/src/appsignal/agent.py
+++ b/src/appsignal/agent.py
@@ -16,6 +16,15 @@ class Agent:
 
     def start(self, config: Config) -> None:
         config.set_private_environ()
+
+        if self.architecture_and_platform() == ["any"]:
+            print(
+                "AppSignal agent is not available for this platform. "
+                "The integration is now running in no-op mode therefore "
+                "no data will be sent to AppSignal."
+            )
+            return
+
         p = subprocess.Popen(
             [self.agent_path, "start", "--private"],
             stdout=subprocess.PIPE,

--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -41,6 +41,8 @@ class Client:
         if self._config.is_active():
             logger.info("Starting AppSignal")
             agent.start(self._config)
+            if not agent.active:
+                return
             start_opentelemetry(self._config)
             self._start_probes()
         else:

--- a/src/scripts/build_hook.py
+++ b/src/scripts/build_hook.py
@@ -114,6 +114,12 @@ class CustomBuildHook(BuildHookInterface):
 
         rm(agent_path)
 
+        if triple == "any":
+            print("Skipping agent download for `any` triple")
+            with open(platform_path, "w") as platform:
+                platform.write(triple)
+            return
+
         tempdir_path = os.path.join(self.root, "tmp", triple)
         os.makedirs(tempdir_path, exist_ok=True)
 

--- a/src/scripts/platform.py
+++ b/src/scripts/platform.py
@@ -19,4 +19,5 @@ TRIPLE_PLATFORM_TAG = {
     # https://peps.python.org/pep-0656/
     "aarch64-linux-musl": "musllinux_1_1_aarch64",
     "x86_64-linux-musl": "musllinux_1_1_x86_64",
+    "any": "any",
 }


### PR DESCRIPTION
Add wildcard triple for unsupported systems

The `any` tag is now installed when downloading the package from an unsupported system.

Don't start components when on unsupported arch

When trying to run the agent, OpenTelemetry and probes on an unsupported system (any-any), prevent the three of them from starting.

Closes #179 