### PR TITLE
Add support for Pika

### DIFF
--- a/.changesets/add-support-for-pika.md
+++ b/.changesets/add-support-for-pika.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Add support for Pika

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -104,6 +104,7 @@ class Config:
         "opentelemetry.instrumentation.jinja2",
         "opentelemetry.instrumentation.mysql",
         "opentelemetry.instrumentation.mysqlclient",
+        "opentelemetry.instrumentation.pika",
         "opentelemetry.instrumentation.psycopg",
         "opentelemetry.instrumentation.psycopg2",
         "opentelemetry.instrumentation.pymysql",

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -103,6 +103,12 @@ def add_mysqlclient_instrumentation() -> None:
     MySQLClientInstrumentor().instrument()
 
 
+def add_pika_instrumentation() -> None:
+    from opentelemetry.instrumentation.pika import PikaInstrumentor
+
+    PikaInstrumentor().instrument()
+
+
 def add_psycopg2_instrumentation() -> None:
     from opentelemetry.instrumentation.psycopg2 import Psycopg2Instrumentor
 
@@ -158,6 +164,7 @@ DEFAULT_INSTRUMENTATION_ADDERS: Mapping[
     "opentelemetry.instrumentation.jinja2": add_jinja2_instrumentation,
     "opentelemetry.instrumentation.mysql": add_mysql_instrumentation,
     "opentelemetry.instrumentation.mysqlclient": add_mysqlclient_instrumentation,
+    "opentelemetry.instrumentation.pika": add_pika_instrumentation,
     "opentelemetry.instrumentation.psycopg2": add_psycopg2_instrumentation,
     "opentelemetry.instrumentation.psycopg": add_psycopg_instrumentation,
     "opentelemetry.instrumentation.pymysql": add_pymysql_instrumentation,


### PR DESCRIPTION
Add instrumentation support for Pika messages. The global messaging extractor already covers the cases this instrumentation adds, so there's no need for a specific extractor so far.

Action with message production:

![image](https://github.com/appsignal/appsignal-python/assets/1941121/429424df-9975-4e4b-965f-a6e81a49ad72)

Consumption action automatically instrumented

![image](https://github.com/appsignal/appsignal-python/assets/1941121/07c13377-10ea-428b-b56d-43d754de66df)

Part of: #181 
