### PR TITLE
Add helper to manually stop agent processes

### DIFF
--- a/.changesets/new-helper-to-manually-stop-all-agent-processes.md
+++ b/.changesets/new-helper-to-manually-stop-all-agent-processes.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: add
+---
+
+Add helper to manually stop the agent process for this AppSignal instance.
+
+Some contexts, like serverless functions, exit before AppSignal can ensure all data is sent to our servers. To ensure the data is sent, the new `appsignal.stop()` method can be called to gracefully stop the AppSignal agent process.


### PR DESCRIPTION
In some specific contexts such as serverless functions, the execution is stopped before the agent gets all the data to send it to AppSignal.

There's a new function that manually allows you to gracefully stop AppSignal's agent processes so all the data is flushed before the execution is closed.

Fixes: #221 