### PR TITLE
Simplify the impementation of the `set_gauge` helper

### DIFF
--- a/.changesets/simplify-the-implementation-of-set_gauge.md
+++ b/.changesets/simplify-the-implementation-of-set_gauge.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Simplify the implementation of `set_gauge` in favor of the newer OpenTelemetry's sync implementation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ classifiers = [
   "Development Status :: 5 - Production/Stable"
 ]
 dependencies = [
-  "opentelemetry-api",
-  "opentelemetry-sdk",
+  "opentelemetry-api>=1.26.0",
+  "opentelemetry-sdk>=1.26.0",
   "opentelemetry-exporter-otlp-proto-http",
 ]
 dynamic = ["version"]

--- a/src/appsignal/metrics.py
+++ b/src/appsignal/metrics.py
@@ -1,14 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any
 
-from opentelemetry.metrics import (
-    CallbackOptions,
-    Histogram,
-    Observation,
-    UpDownCounter,
-    get_meter,
-)
+from opentelemetry.metrics import Histogram, UpDownCounter, _Gauge, get_meter
 
 
 if TYPE_CHECKING:
@@ -42,37 +36,14 @@ def add_distribution_value(name: str, value: int | float, tags: Tags = None) -> 
     histogram.record(value, tags)
 
 
-_gauges: dict[str, dict[TagsKey, int | float]] = {}
-
-
-def _create_gauge(name: str) -> None:
-    def gauge_callback(options: CallbackOptions) -> Iterable[Observation]:
-        gauge_entries = _gauges.get(name)
-        if gauge_entries is None:
-            return []
-
-        observations = []
-        for key, value in gauge_entries.items():
-            tags = None if key is None else dict(key)
-
-            observations.append(Observation(value, tags))
-
-        _gauges[name] = {}
-
-        return observations
-
-    _meter.create_observable_gauge(
-        name,
-        callbacks=[gauge_callback],
-    )
+_gauges: dict[str, _Gauge] = {}
 
 
 def set_gauge(name: str, value: float, tags: Tags = None) -> None:
-    if name not in _gauges:
-        # Create dict for every tag combination
-        _gauges[name] = {}
-        _create_gauge(name)
+    if name in _gauges:
+        gauge = _gauges[name]
+    else:
+        gauge = _meter.create_gauge(name)
+        _gauges[name] = gauge
 
-    key = (frozenset(tags.items())) if tags is not None else None
-
-    _gauges[name][key] = value
+    gauge.set(value, tags)


### PR DESCRIPTION
The `set_gauge` now uses OpenTelemetry's newer helper, which creates a sync gauge.

Our own implementation of `create_gauge` around the async OpenTelemetry's implementation has been removed in favor of the newer sync helper.

Closes #220 