### PR TITLE
Update config for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,16 @@
 name: Python package
 on:
-  push: {}
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
   schedule:
-    - cron: "0 0 * * 1-5"
+    - cron: 0 0 * * 1-5
 jobs:
   test:
     name: "Test Python ${{ matrix.python-version }}"


### PR DESCRIPTION
Trigger CI builds on new PR creation. This also allows us to run the CI for PRs from forks.

The main and develop branch will also run when pushed.

[skip changeset]
[skip review]