### PR TITLE
Lock linters to latest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,10 +79,10 @@ python = ["38", "39", "310", "311", "312"]
 [tool.hatch.envs.lint]
 detached = true
 dependencies = [
-  "black>=23.1.0",
-  "mypy>=1.0.0",
-  "isort",
-  "ruff>=0.0.243",
+  "black==24.1.0",
+  "mypy==1.13.0",
+  "isort==5.13.2",
+  "ruff==0.8.0",
 
   "opentelemetry-api",
   "opentelemetry-sdk",


### PR DESCRIPTION
Lock `ruff`, `black`, `isort` and `mypy` to the latest version. We should update these from time to time.

[skip changeset]