### PR TITLE
Call `scheduler.stop()` when AppSignal stops

### DIFF
--- a/.changesets/fix-scheduler-stop.md
+++ b/.changesets/fix-scheduler-stop.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix an issue where calling `appsignal.stop()` after sending check-in events would leave a dangling thread, stopping the application from shutting down correctly.

--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -52,7 +52,10 @@ class Client:
             logger.info("AppSignal not starting: no active config found")
 
     def stop(self) -> None:
+        from .check_in.scheduler import scheduler
+
         logger.info("Stopping AppSignal")
+        scheduler().stop()
         working_dir = self._config.option("working_directory_path") or "/tmp/appsignal"
         lock_path = os.path.join(working_dir, "agent.lock")
         try:


### PR DESCRIPTION
When `appsignal.stop()` is called on the AppSignal client, it should call `scheduler.stop()` to stop the scheduler, killing the thread and allowing for the application to finish.

Fixes #233.