### PR TITLE
Remove redundant cron check-in pairs

### DIFF
--- a/.changesets/remove-redundant-cron-check-in-pairs.md
+++ b/.changesets/remove-redundant-cron-check-in-pairs.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Remove redundant cron check-in pairs. When more than one pair of start and finish cron check-in events is reported for the same identifier in the same period, only one of them will be reported to AppSignal.

--- a/src/appsignal/check_in/scheduler.py
+++ b/src/appsignal/check_in/scheduler.py
@@ -9,7 +9,7 @@ from .. import internal_logger as logger
 from ..client import Client
 from ..config import Config
 from ..transmitter import transmit
-from .event import Event, describe, is_redundant
+from .event import Event, deduplicate_cron, describe, is_redundant
 
 
 class Scheduler:
@@ -133,7 +133,9 @@ class Scheduler:
     def _push_events(self) -> None:
         if not self.events:
             return
-        self.queue.put(self.events.copy())
+        events_copy = self.events.copy()
+        deduplicate_cron(events_copy)
+        self.queue.put(events_copy)
         self.events.clear()
         self._start_waker(self.BETWEEN_TRANSMISSIONS_DEBOUNCE_SECONDS)
 


### PR DESCRIPTION
See https://github.com/appsignal/appsignal-ruby/pull/1407 for context. This commit reimplements that in Python.

Before submitting a batch of cron check-in events, check for any pairs of events that are redundant with other pairs of cron check-in events. This would happen, for example, when running a `cron` block for a given identifier many times in quick succession.

A redundant pair of cron check-in events is a pair of start and finish cron check-in events for a given identifier, given that another pair of start and finish check-in events exists for that identifier.