### PR TITLE
Add `nginx_port` configuration option

### DIFF
--- a/.changesets/add--nginx_port--configuration-option.md
+++ b/.changesets/add--nginx_port--configuration-option.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Add `nginxPort` configuration option. This configuration option can be used to customize the port on which the AppSignal integration exposes [the NGINX metrics server](https://docs.appsignal.com/metrics/nginx.html).

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -38,6 +38,7 @@ class Options(TypedDict, total=False):
     log_level: str | None
     log_path: str | None
     logging_endpoint: str | None
+    nginx_port: str | int | None
     opentelemetry_port: str | int | None
     name: str | None
     push_api_key: str | None
@@ -184,6 +185,7 @@ class Config:
             log_level=os.environ.get("APPSIGNAL_LOG_LEVEL"),
             log_path=os.environ.get("APPSIGNAL_LOG_PATH"),
             logging_endpoint=os.environ.get("APPSIGNAL_LOGGING_ENDPOINT"),
+            nginx_port=os.environ.get("APPSIGNAL_NGINX_PORT"),
             opentelemetry_port=os.environ.get("APPSIGNAL_OPENTELEMETRY_PORT"),
             name=os.environ.get("APPSIGNAL_APP_NAME"),
             push_api_key=os.environ.get("APPSIGNAL_PUSH_API_KEY"),
@@ -252,6 +254,7 @@ class Config:
             "_APPSIGNAL_LOG_LEVEL": options.get("log_level"),
             "_APPSIGNAL_LOG_FILE_PATH": self.log_file_path(),
             "_APPSIGNAL_LOGGING_ENDPOINT": options.get("logging_endpoint"),
+            "_APPSIGNAL_NGINX_PORT": options.get("nginx_port"),
             "_APPSIGNAL_OPENTELEMETRY_PORT": options.get("opentelemetry_port"),
             "_APPSIGNAL_PUSH_API_KEY": options.get("push_api_key"),
             "_APPSIGNAL_PUSH_API_ENDPOINT": options.get("endpoint"),

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -19,7 +19,7 @@ from opentelemetry.sdk.metrics.export import (
     AggregationTemporality,
     PeriodicExportingMetricReader,
 )
-from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.resources import Resource  # type: ignore[attr-defined]
 from opentelemetry.sdk.trace import ConcurrentMultiSpanProcessor, TracerProvider
 from opentelemetry.sdk.trace.export import (
     BatchSpanProcessor,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,6 +64,7 @@ def test_environ_source():
     os.environ["APPSIGNAL_IGNORE_NAMESPACES"] = "namespace1,namespace2"
     os.environ["APPSIGNAL_LOG_LEVEL"] = "trace"
     os.environ["APPSIGNAL_LOG_PATH"] = "/path/to/log_dir"
+    os.environ["APPSIGNAL_NGINX_PORT"] = "8080"
     os.environ["APPSIGNAL_OPENTELEMETRY_PORT"] = "9002"
     os.environ["APPSIGNAL_PUSH_API_KEY"] = "some-api-key"
     os.environ["APPSIGNAL_PUSH_API_ENDPOINT"] = "https://push.appsignal.com"
@@ -100,6 +101,7 @@ def test_environ_source():
         ignore_namespaces=["namespace1", "namespace2"],
         log_level="trace",
         log_path="/path/to/log_dir",
+        nginx_port="8080",
         opentelemetry_port="9002",
         name="MyApp",
         push_api_key="some-api-key",
@@ -198,6 +200,7 @@ def test_set_private_environ():
             ignore_namespaces=["namespace1", "namespace2"],
             log_level="trace",
             log_path=cwdir,
+            nginx_port=8080,
             opentelemetry_port=9002,
             name="MyApp",
             push_api_key="some-api-key",
@@ -235,6 +238,7 @@ def test_set_private_environ():
     assert os.environ["_APPSIGNAL_IGNORE_NAMESPACES"] == "namespace1,namespace2"
     assert os.environ["_APPSIGNAL_LOG_LEVEL"] == "trace"
     assert os.environ["_APPSIGNAL_LOG_FILE_PATH"] == f"{cwdir}/appsignal.log"
+    assert os.environ["_APPSIGNAL_NGINX_PORT"] == "8080"
     assert os.environ["_APPSIGNAL_OPENTELEMETRY_PORT"] == "9002"
     assert os.environ["_APPSIGNAL_PUSH_API_KEY"] == "some-api-key"
     assert os.environ["_APPSIGNAL_PUSH_API_ENDPOINT"] == "https://push.appsignal.com"


### PR DESCRIPTION
**⚠️ This PR cannot be merged until a release of the agent containing appsignal/appsignal-agent#1275 has been released and its agent file merged into this repository. ⚠️** 

Implement an `nginx_port` configuration option that is passed on to the agent, like the existing `statsd_port` and `opentelemetry_port` configuration options.