### PR TITLE
Remove `type: ignore` annotation

### DIFF
--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -19,7 +19,7 @@ from opentelemetry.sdk.metrics.export import (
     AggregationTemporality,
     PeriodicExportingMetricReader,
 )
-from opentelemetry.sdk.resources import Resource  # type: ignore[attr-defined]
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import ConcurrentMultiSpanProcessor, TracerProvider
 from opentelemetry.sdk.trace.export import (
     BatchSpanProcessor,


### PR DESCRIPTION
This commit reverts 3cfb6956ac9bea6eb20d4d180af5af03555b0d1f -- the underlying cause was [a bug in the previous OpenTelemetry release][bug] that has been [fixed in the latest release][fix]

[bug]: https://github.com/open-telemetry/opentelemetry-python/issues/4615#issuecomment-2946177912
[fix]: https://github.com/open-telemetry/opentelemetry-python/pull/4618