### PR TITLE
Fix custom agent build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ hatch run build:for <triple> # for a specific agent triple
 hatch run build:me /path/to/agent
 # or place the desired agent binary at
 # `src/appsignal/appsignal-agent`, and then:
-hatch run build:me --keep-agent
+ _APPSIGNAL_BUILD_AGENT_PATH="--keep-agent" hatch run build:me --keep-agent
 ```
 
 ### Clean up build artifacts


### PR DESCRIPTION
Currently, [README.md suggests](https://github.com/appsignal/appsignal-python/blob/ddec240cefa70dc8f01217e4737b19401a7294ab/README.md?plain=1#L94) that running `hatch run build:me --keep-agent` will keep the agent binary from the `src/appsignal` directory intact. But as a part of the build environment setup, `hatch` installs project in development mode, which runs the `src/scripts/build_hook.py` script. This results in the script discarding the local binary, despite the `--keep-agent` flag.

This change adds `_APPSIGNAL_BUILD_AGENT_PATH` env variable to the build script, so that it is picked up by the project installation and build steps.

[skip ci]