### PR TITLE
Add collector attributes config options

### DIFF
--- a/src/appsignal/client.py
+++ b/src/appsignal/client.py
@@ -46,6 +46,7 @@ class Client:
 
         if self._config.is_active():
             logger.info("Starting AppSignal")
+            self._config.warn()
             self._binary.start(self._config)
             if not self._binary.active:
                 return

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import os
 import platform
+import socket
 import tempfile
 from typing import Any, ClassVar, List, Literal, TypedDict, cast, get_args
 
+from . import internal_logger as logger
 from .__about__ import __version__
 
 
@@ -27,7 +29,11 @@ class Options(TypedDict, total=False):
     endpoint: str | None
     environment: str | None
     files_world_accessible: bool | None
+    filter_attributes: list[str] | None
+    filter_function_parameters: list[str] | None
     filter_parameters: list[str] | None
+    filter_request_payload: list[str] | None
+    filter_request_query_parameters: list[str] | None
     filter_session_data: list[str] | None
     hostname: str | None
     host_role: str | None
@@ -45,9 +51,13 @@ class Options(TypedDict, total=False):
     push_api_key: str | None
     revision: str | None
     request_headers: list[str] | None
+    response_headers: list[str] | None
     running_in_container: bool | None
     send_environment_metadata: bool | None
+    send_function_parameters: bool | None
     send_params: bool | None
+    send_request_payload: bool | None
+    send_request_query_parameters: bool | None
     send_session_data: bool | None
     service_name: str | None
     statsd_port: str | int | None
@@ -146,7 +156,13 @@ class Config:
     # Whether it should instrument logging.
     def should_instrument_logging(self) -> bool:
         # The agent does not support logging, so this is equivalent
-        # to whether it should use an external collector.
+        # to whether it should use a collector.
+        return self.should_use_collector()
+
+    # Whether it should use a collector to send data to AppSignal.
+    def should_use_collector(self) -> bool:
+        # This is currently equivalent to whether it should use an
+        # external collector.
         return self.should_use_external_collector()
 
     # Whether it should use a collector to send data to AppSignal
@@ -156,7 +172,10 @@ class Config:
 
     @staticmethod
     def load_from_system() -> Options:
-        return Options(app_path=os.getcwd())
+        return Options(
+            app_path=os.getcwd(),
+            hostname=os.environ.get("HOSTNAME") or socket.gethostname(),
+        )
 
     @staticmethod
     def load_from_environment() -> Options:
@@ -186,7 +205,17 @@ class Config:
             files_world_accessible=parse_bool(
                 os.environ.get("APPSIGNAL_FILES_WORLD_ACCESSIBLE")
             ),
+            filter_attributes=parse_list(os.environ.get("APPSIGNAL_FILTER_ATTRIBUTES")),
+            filter_function_parameters=parse_list(
+                os.environ.get("APPSIGNAL_FILTER_FUNCTION_PARAMETERS")
+            ),
             filter_parameters=parse_list(os.environ.get("APPSIGNAL_FILTER_PARAMETERS")),
+            filter_request_payload=parse_list(
+                os.environ.get("APPSIGNAL_FILTER_REQUEST_PAYLOAD")
+            ),
+            filter_request_query_parameters=parse_list(
+                os.environ.get("APPSIGNAL_FILTER_REQUEST_QUERY_PARAMETERS")
+            ),
             filter_session_data=parse_list(
                 os.environ.get("APPSIGNAL_FILTER_SESSION_DATA")
             ),
@@ -206,13 +235,23 @@ class Config:
             push_api_key=os.environ.get("APPSIGNAL_PUSH_API_KEY"),
             revision=os.environ.get("APP_REVISION"),
             request_headers=parse_list(os.environ.get("APPSIGNAL_REQUEST_HEADERS")),
+            response_headers=parse_list(os.environ.get("APPSIGNAL_RESPONSE_HEADERS")),
             running_in_container=parse_bool(
                 os.environ.get("APPSIGNAL_RUNNING_IN_CONTAINER")
             ),
             send_environment_metadata=parse_bool(
                 os.environ.get("APPSIGNAL_SEND_ENVIRONMENT_METADATA")
             ),
+            send_function_parameters=parse_bool(
+                os.environ.get("APPSIGNAL_SEND_FUNCTION_PARAMETERS")
+            ),
             send_params=parse_bool(os.environ.get("APPSIGNAL_SEND_PARAMS")),
+            send_request_payload=parse_bool(
+                os.environ.get("APPSIGNAL_SEND_REQUEST_PAYLOAD")
+            ),
+            send_request_query_parameters=parse_bool(
+                os.environ.get("APPSIGNAL_SEND_REQUEST_QUERY_PARAMETERS")
+            ),
             send_session_data=parse_bool(os.environ.get("APPSIGNAL_SEND_SESSION_DATA")),
             service_name=os.environ.get("APPSIGNAL_SERVICE_NAME"),
             statsd_port=os.environ.get("APPSIGNAL_STATSD_PORT"),
@@ -328,6 +367,116 @@ class Config:
         push_api_key = self.option("push_api_key") or ""
         if len(push_api_key.strip()) > 0:
             self.valid = True
+
+    def warn(self) -> None:
+        if self.should_use_collector():
+            self._warn_agent_exclusive_options()
+        else:
+            self._warn_collector_exclusive_options()
+
+    # Emit a warning if agent-exclusive configuration options are used.
+    def _warn_agent_exclusive_options(self) -> None:
+        agent_exclusive_options = [
+            "bind_address",
+            "cpu_count",
+            "dns_servers",
+            "enable_host_metrics",
+            "enable_nginx_metrics",
+            "enable_statsd",
+            "files_world_accessible",
+            "filter_parameters",
+            "host_role",
+            "nginx_port",
+            "opentelemetry_port",
+            "running_in_container",
+            "send_environment_metadata",
+            "send_params",
+            "working_directory_path",
+            "statsd_port",
+        ]
+
+        option_specific_warnings = {
+            "filter_parameters": (
+                "Use the 'filter_attributes', 'filter_function_parameters',"
+                " 'filter_request_payload' and 'filter_request_query_parameters'"
+                " configuration options instead."
+            ),
+            "send_params": (
+                "Use the 'send_function_parameters', 'send_request_payload'"
+                " and 'send_request_query_parameters' configuration options instead."
+            ),
+            "opentelemetry_port": (
+                "Set the collector's OpenTelemetry port as part of the"
+                " 'collector_endpoint' configuration option."
+            ),
+        }
+
+        non_default_options = self._filter_non_default_options(agent_exclusive_options)
+
+        for option in non_default_options:
+            logger.warning(
+                f"The collector is in use. The '{option}' configuration option"
+                " is only used by the agent and will be ignored."
+            )
+            if option in option_specific_warnings:
+                logger.warning(option_specific_warnings[option])
+
+        if non_default_options:
+            logger.info(
+                "To use the agent, unset the 'collector_endpoint' configuration option."
+            )
+
+    # Emit a warning if collector-exclusive configuration options are used.
+    def _warn_collector_exclusive_options(self) -> None:
+        collector_exclusive_options = [
+            "filter_attributes",
+            "filter_function_parameters",
+            "filter_request_payload",
+            "filter_request_query_parameters",
+            "response_headers",
+            "send_function_parameters",
+            "send_request_payload",
+            "send_request_query_parameters",
+        ]
+
+        filter_warning = "Use the 'filter_parameters' option instead."
+        send_warning = "Use the 'send_params' option instead."
+
+        option_specific_warnings = {
+            "filter_attributes": filter_warning,
+            "filter_function_parameters": filter_warning,
+            "filter_request_payload": filter_warning,
+            "filter_request_query_parameters": filter_warning,
+            "send_function_parameters": send_warning,
+            "send_request_payload": send_warning,
+            "send_request_query_parameters": send_warning,
+        }
+
+        non_default_options = self._filter_non_default_options(
+            collector_exclusive_options
+        )
+
+        for option in non_default_options:
+            logger.warning(
+                f"The agent is in use. The '{option}' configuration option"
+                " is only used by the collector and will be ignored."
+            )
+            if option in option_specific_warnings:
+                logger.warning(option_specific_warnings[option])
+
+        if non_default_options:
+            logger.info(
+                "To use the collector, set the 'collector_endpoint' configuration option."
+            )
+
+    # Filter a list of options, returning a list of those options for which
+    # the value differs from that of the default configuration.
+    def _filter_non_default_options(self, options: list[str]) -> list[str]:
+        return [
+            option
+            for option in options
+            if self.option(option) != self.sources["default"].get(option)
+        ]
 
 
 def parse_bool(value: str | None) -> bool | None:

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Callable, Mapping
+from typing import TYPE_CHECKING, Callable, List, Mapping, Union, cast
 
 from opentelemetry import _logs as logs
 from opentelemetry import metrics, trace
@@ -279,7 +279,7 @@ def _start_logging(config: Config) -> None:
 
 def _resource(config: Config) -> Resource:
     attributes = {
-        key: str(value)
+        key: value
         for key, value in {
             "appsignal.config.name": config.options.get("name"),
             "appsignal.config.environment": config.options.get("environment"),
@@ -287,13 +287,47 @@ def _resource(config: Config) -> Resource:
             "appsignal.config.revision": config.options.get("revision", "unknown"),
             "appsignal.config.language_integration": "python",
             "service.name": config.options.get("service_name", "unknown"),
-            "host.name": config.options.get("hostname", os.uname().nodename),
+            "host.name": config.options.get("hostname", "unknown"),
             "appsignal.service.process_id": os.getpid(),
+            "appsignal.config.filter_attributes": config.options.get(
+                "filter_attributes"
+            ),
+            "appsignal.config.filter_function_parameters": config.options.get(
+                "filter_function_parameters"
+            ),
+            "appsignal.config.filter_request_query_parameters": config.options.get(
+                "filter_request_query_parameters"
+            ),
+            "appsignal.config.filter_request_payload": config.options.get(
+                "filter_request_payload"
+            ),
+            "appsignal.config.filter_request_session_data": config.options.get(
+                "filter_session_data"
+            ),
+            "appsignal.config.ignore_actions": config.options.get("ignore_actions"),
+            "appsignal.config.ignore_errors": config.options.get("ignore_errors"),
+            "appsignal.config.ignore_namespaces": config.options.get(
+                "ignore_namespaces"
+            ),
+            "appsignal.config.response_headers": config.options.get("response_headers"),
+            "appsignal.config.request_headers": config.options.get("request_headers"),
+            "appsignal.config.send_function_parameters": config.options.get(
+                "send_function_parameters"
+            ),
+            "appsignal.config.send_request_query_parameters": config.options.get(
+                "send_request_query_parameters"
+            ),
+            "appsignal.config.send_request_payload": config.options.get(
+                "send_request_payload"
+            ),
+            "appsignal.config.send_request_session_data": config.options.get(
+                "send_session_data"
+            ),
         }.items()
         if value is not None
     }
 
-    return Resource(attributes=attributes)
+    return Resource(attributes=cast(Mapping[str, Union[str, List[str]]], attributes))
 
 
 def _opentelemetry_endpoint(config: Config) -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,8 +38,9 @@ def test_source_order():
 def test_system_source():
     config = Config()
 
-    assert list(config.sources["system"].keys()) == ["app_path"]
+    assert list(config.sources["system"].keys()) == ["app_path", "hostname"]
     assert "app_path" in list(config.options.keys())
+    assert "hostname" in list(config.options.keys())
 
 
 def test_environ_source():
@@ -252,6 +253,102 @@ def test_set_private_environ():
     assert os.environ["_APP_REVISION"] == "abc123"
 
 
+def test_opentelemetry_resource():
+    import os
+
+    from appsignal.opentelemetry import _resource
+
+    config = Config(
+        Options(
+            name="TestApp",
+            environment="test",
+            push_api_key="test-key",
+            revision="abc123",
+            service_name="test-service",
+            hostname="test-host",
+            filter_attributes=["password", "secret"],
+            filter_function_parameters=["param1"],
+            filter_request_query_parameters=["query1"],
+            filter_request_payload=["payload1"],
+            filter_session_data=["session1"],
+            ignore_actions=["action1", "action2"],
+            ignore_errors=["error1"],
+            ignore_namespaces=["namespace1"],
+            response_headers=["x-response"],
+            request_headers=["x-request"],
+            send_function_parameters=True,
+            send_request_query_parameters=True,
+            send_request_payload=True,
+            send_session_data=True,
+        )
+    )
+
+    resource = _resource(config)
+
+    # Test required attributes
+    assert resource.attributes["appsignal.config.name"] == "TestApp"
+    assert resource.attributes["appsignal.config.environment"] == "test"
+    assert resource.attributes["appsignal.config.push_api_key"] == "test-key"
+    assert resource.attributes["appsignal.config.revision"] == "abc123"
+    assert resource.attributes["appsignal.config.language_integration"] == "python"
+    assert resource.attributes["service.name"] == "test-service"
+    assert resource.attributes["host.name"] == "test-host"
+    assert resource.attributes["appsignal.service.process_id"] == os.getpid()
+
+    # Test filter attributes
+    assert resource.attributes["appsignal.config.filter_attributes"] == (
+        "password",
+        "secret",
+    )
+    assert resource.attributes["appsignal.config.filter_function_parameters"] == (
+        "param1",
+    )
+    assert resource.attributes["appsignal.config.filter_request_query_parameters"] == (
+        "query1",
+    )
+    assert resource.attributes["appsignal.config.filter_request_payload"] == (
+        "payload1",
+    )
+    assert resource.attributes["appsignal.config.filter_request_session_data"] == (
+        "session1",
+    )
+
+    # Test ignore attributes
+    assert resource.attributes["appsignal.config.ignore_actions"] == (
+        "action1",
+        "action2",
+    )
+    assert resource.attributes["appsignal.config.ignore_errors"] == ("error1",)
+    assert resource.attributes["appsignal.config.ignore_namespaces"] == ("namespace1",)
+
+    # Test header attributes
+    assert resource.attributes["appsignal.config.response_headers"] == ("x-response",)
+    assert resource.attributes["appsignal.config.request_headers"] == ("x-request",)
+
+    # Test send attributes
+    assert resource.attributes["appsignal.config.send_function_parameters"] is True
+    assert resource.attributes["appsignal.config.send_request_query_parameters"] is True
+    assert resource.attributes["appsignal.config.send_request_payload"] is True
+    assert resource.attributes["appsignal.config.send_request_session_data"] is True
+
+
+def test_opentelemetry_resource_with_defaults():
+    from appsignal.opentelemetry import _resource
+
+    # Test with minimal config to check default values
+    config = Config(Options())
+    resource = _resource(config)
+
+    # Test default values
+    assert resource.attributes["appsignal.config.revision"] == "unknown"
+    assert resource.attributes["service.name"] == "unknown"
+    assert resource.attributes["appsignal.config.language_integration"] == "python"
+
+    # Test that None values are excluded
+    assert "appsignal.config.name" not in resource.attributes
+    assert "appsignal.config.push_api_key" not in resource.attributes
+
+
 def test_set_private_environ_valid_log_path():
     cwdir = os.getcwd()
     config = Config(Options(log_path=cwdir))
@@ -318,3 +415,225 @@ def test_is_active_invalid_push_api_key():
 
     config = Config(Options(active=True, push_api_key="  "))
     assert config.is_active() is False
+
+
+def test_warn_no_warnings_when_using_default_values(mocker):
+    mock_warning = mocker.patch("appsignal.internal_logger.warning")
+
+    # Using collector with default values should not emit warnings
+    config = Config(Options(collector_endpoint="http://localhost:4318"))
+    config.warn()
+
+    assert mock_warning.call_count == 0
+
+    # Using agent with default values should not emit warnings
+    config = Config(Options())
+    config.warn()
+
+    assert mock_warning.call_count == 0
+
+
+def test_warn_all_agent_exclusive_options(mocker):
+    mock_warning = mocker.patch("appsignal.internal_logger.warning")
+    mock_info = mocker.patch("appsignal.internal_logger.info")
+
+    config = Config(
+        Options(
+            collector_endpoint="http://localhost:4318",
+            bind_address="0.0.0.0",
+            cpu_count=2.0,
+            dns_servers=["8.8.8.8"],
+            enable_host_metrics=False,
+            enable_nginx_metrics=True,
+            enable_statsd=True,
+            files_world_accessible=False,
+            filter_parameters=["password"],
+            host_role="web",
+            nginx_port="8080",
+            opentelemetry_port="9999",
+            running_in_container=True,
+            send_environment_metadata=False,
+            send_params=False,
+            working_directory_path="/app",
+            statsd_port="8125",
+        )
+    )
+
+    config.warn()
+
+    warning_messages = [call.args[0] for call in mock_warning.call_args_list]
+
+    agent_exclusive_options = [
+        "bind_address",
+        "cpu_count",
+        "dns_servers",
+        "enable_host_metrics",
+        "enable_nginx_metrics",
+        "enable_statsd",
+        "files_world_accessible",
+        "filter_parameters",
+        "host_role",
+        "nginx_port",
+        "opentelemetry_port",
+        "running_in_container",
+        "send_environment_metadata",
+        "send_params",
+        "working_directory_path",
+        "statsd_port",
+    ]
+
+    for option in agent_exclusive_options:
+        assert any(
+            f"'{option}' configuration option is only used by the agent" in msg
+            for msg in warning_messages
+        ), f"Expected warning for '{option}' not found"
+
+    # Info log about using the agent should only be emitted once
+    mock_info.assert_called_once_with(
+        "To use the agent, unset the 'collector_endpoint' configuration option."
+    )
+
+
+def test_warn_all_collector_exclusive_options(mocker):
+    mock_warning = mocker.patch("appsignal.internal_logger.warning")
+    mock_info = mocker.patch("appsignal.internal_logger.info")
+
+    config = Config(
+        Options(
+            filter_attributes=["attr1"],
+            filter_function_parameters=["param1"],
+            filter_request_payload=["payload1"],
+            filter_request_query_parameters=["query1"],
+            response_headers=["x-response"],
+            send_function_parameters=True,
+            send_request_payload=True,
+            send_request_query_parameters=True,
+        )
+    )
+
+    config.warn()
+
+    warning_messages = [call.args[0] for call in mock_warning.call_args_list]
+
+    collector_exclusive_options = [
+        "filter_attributes",
+        "filter_function_parameters",
+        "filter_request_payload",
+        "filter_request_query_parameters",
+        "response_headers",
+        "send_function_parameters",
+        "send_request_payload",
+        "send_request_query_parameters",
+    ]
+
+    for option in collector_exclusive_options:
+        assert any(
+            f"'{option}' configuration option is only used by the collector" in msg
+            for msg in warning_messages
+        ), f"Expected warning for '{option}' not found"
+
+    # Info log about using the collector should only be emitted once
+    mock_info.assert_called_once_with(
+        "To use the collector, set the 'collector_endpoint' configuration option."
+    )
+
+
+def test_warn_filter_parameters_emits_specific_advice(mocker):
+    mock_warning = mocker.patch("appsignal.internal_logger.warning")
+
+    config = Config(
+        Options(
+            collector_endpoint="http://localhost:4318",
+            filter_parameters=["password"],
+        )
+    )
+
+    config.warn()
+
+    warning_messages = [call.args[0] for call in mock_warning.call_args_list]
+
+    assert any(
+        "Use the 'filter_attributes', 'filter_function_parameters',"
+        " 'filter_request_payload' and 'filter_request_query_parameters'"
+        " configuration options instead." in msg
+        for msg in warning_messages
+    ), "Expected specific advice for 'filter_parameters' not found"
+
+
+def test_warn_send_params_emits_specific_advice(mocker):
+    mock_warning = mocker.patch("appsignal.internal_logger.warning")
+
+    config = Config(
+        Options(
+            collector_endpoint="http://localhost:4318",
+            send_params=False,
+        )
+    )
+
+    config.warn()
+
+    warning_messages = [call.args[0] for call in mock_warning.call_args_list]
+
+    assert any(
+        "Use the 'send_function_parameters', 'send_request_payload'"
+        " and 'send_request_query_parameters' configuration options instead." in msg
+        for msg in warning_messages
+    ), "Expected specific advice for 'send_params' not found"
+
+
+def test_warn_opentelemetry_port_emits_specific_advice(mocker):
+    mock_warning = mocker.patch("appsignal.internal_logger.warning")
+
+    config = Config(
+        Options(
+            collector_endpoint="http://localhost:4318",
+            opentelemetry_port="9999",
+        )
+    )
+
+    config.warn()
+
+    warning_messages = [call.args[0] for call in mock_warning.call_args_list]
+
+    assert any(
+        "Set the collector's OpenTelemetry port as part of the"
+        " 'collector_endpoint' configuration option." in msg
+        for msg in warning_messages
+    ), "Expected specific advice for 'opentelemetry_port' not found"
+
+
+def test_warn_collector_filter_options_emit_use_filter_parameters_advice(mocker):
+    mock_warning = mocker.patch("appsignal.internal_logger.warning")
+
+    config = Config(
+        Options(
+            filter_attributes=["attr1"],
+            filter_function_parameters=["param1"],
+            filter_request_payload=["payload1"],
+            filter_request_query_parameters=["query1"],
+        )
+    )
+
+    config.warn()
+
+    warning_messages = [call.args[0] for call in mock_warning.call_args_list]
+
+    assert warning_messages.count("Use the 'filter_parameters' option instead.") == 4
+
+
+def test_warn_collector_send_options_emit_use_send_params_advice(mocker):
+    mock_warning = mocker.patch("appsignal.internal_logger.warning")
+
+    config = Config(
+        Options(
+            send_function_parameters=True,
+            send_request_payload=True,
+            send_request_query_parameters=True,
+        )
+    )
+
+    config.warn()
+
+    warning_messages = [call.args[0] for call in mock_warning.call_args_list]
+
+    assert warning_messages.count("Use the 'send_params' option instead.") == 3


### PR DESCRIPTION
This is work I realised needed doing while working on documenting the configuration options for the [collector endpoint PR](https://github.com/appsignal/appsignal-python/pull/247).

See https://github.com/appsignal/diagnose_tests/pull/142 for diagnose tests update.

---

Implement the following configuration options in the integration, mapping to the collector-supported, `appsignal.config.`-prefixed resource attribute of the same name:

- `filter_attributes`
- `filter_function_parameters`
- `filter_request_query_parameters`
- `filter_request_payload`
- `response_headers`
- `send_function_parameters`
- `send_request_query_parameters`
- `send_request_payload`

Additionally, also map the following existing configuration options in the integrations to resource attributes in the same manner:

- `filter_session_data` (mapped to `filter_request_session_data`)
- `ignore_actions`
- `ignore_errors`
- `ignore_namespaces`
- `request_headers`
- `send_session_data` (mapped to `send_request_session_data`)

When validating the configuration, if the configuration would trigger the use of the collector, emit a warning about any configuration options set to non-default values which have no effect when using the collector. Do the same when the agent would be used for configuration options that would have no effect when using the agent.