### PR TITLE
Add `requests` dependency to `hatch-build` env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,9 @@ for = "_APPSIGNAL_BUILD_TRIPLE=\"{args}\" hatch build -t wheel"
 path = "src/scripts/build_hook.py"
 dependencies = ["requests"]
 
+[tool.hatch.envs.hatch-build]
+dependencies = ["requests"]
+
 [tool.hatch.build.targets.sdist.hooks.custom]
 path = "src/scripts/sdist_hook.py"
 


### PR DESCRIPTION
Continuation of #252 -- this should _actually_ fix the failing test setups' CI. The changes in #252 fixed the issue for me when building the package locally, but they did not fix it when the test setups build the package. I'm unsure what the difference is.

After changes in Hatch 1.16, it seems that the build hook script is sometimes ran within the `hatch-build` environment, rather than in the `build` environment it is declared for. As such, the `requests` dependency for the build hook must be declared for this environment, as well as for the script itself.