### PR TITLE
Daemonise scheduler threads

### DIFF
--- a/.changesets/fix-an-issue-where-using-check-ins-blocks-the-application-from-shutting-down.md
+++ b/.changesets/fix-an-issue-where-using-check-ins-blocks-the-application-from-shutting-down.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix an issue where using check-ins blocks the application from shutting down.

--- a/src/appsignal/check_in/scheduler.py
+++ b/src/appsignal/check_in/scheduler.py
@@ -55,7 +55,7 @@ class Scheduler:
             logger.debug(f"Scheduling {describe([event])} to be transmitted")
 
             if self.thread is None:
-                self.thread = Thread(target=self._run)
+                self.thread = Thread(target=self._run, daemon=True)
                 self.thread.start()
 
     def stop(self) -> None:
@@ -118,7 +118,7 @@ class Scheduler:
         self._stop_waker()
 
         kill = ThreadEvent()
-        thread = Thread(target=self._run_waker, args=(debounce, kill))
+        thread = Thread(target=self._run_waker, daemon=True, args=(debounce, kill))
         thread.start()
         self.waker = kill
 


### PR DESCRIPTION
This fixes an issue where using check-ins blocks the customer's application from closing. Follow up to #257, which fixed this for continuous heartbeat threads -- but as continuous heartbeat threads cause the scheduler to spawn threads of its own, it didn't actually fix it at all.