### PR TITLE
Fix CI by pinning virtualenv version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: "Install hatch"
-        run: "pip install hatch"
+        run: "pip install hatch \"virtualenv<21.0.0\""
       - name: "Run tests"
         run: "hatch -v run test.py$(echo ${{ matrix.python-version }} | tr -d '.'):pytest"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: "Install hatch"
-        run: "pip install hatch \"click<8.3.0\""
+        run: "pip install hatch"
       - name: "Run tests"
         run: "hatch -v run test.py$(echo ${{ matrix.python-version }} | tr -d '.'):pytest"
 
@@ -40,7 +40,7 @@ jobs:
         with:
           python-version: 3.12
       - name: "Install hatch"
-        run: "pip install hatch \"click<8.3.0\""
+        run: "pip install hatch"
       - name: "Build package"
         run: "hatch run build:all"
       - name: "Ensure package has been built"
@@ -61,7 +61,7 @@ jobs:
           ruby-version: "3.3"
           bundler-cache: true
       - name: "Install hatch"
-        run: "pip install hatch \"click<8.3.0\""
+        run: "pip install hatch"
       - name: "Init Git submodules"
         run: "git submodule init"
       - name: "Update Git submodules"
@@ -78,7 +78,7 @@ jobs:
         with:
           python-version: 3.12
       - name: "Install hatch"
-        run: "pip install hatch \"click<8.3.0\""
+        run: "pip install hatch"
       - name: "Run style linter"
         run: "hatch -v run lint:style"
 
@@ -91,7 +91,7 @@ jobs:
         with:
           python-version: 3.12
       - name: "Install hatch"
-        run: "pip install hatch \"click<8.3.0\""
+        run: "pip install hatch"
       - name: "Run typing linter"
         run: "hatch -v run lint:typing"
 


### PR DESCRIPTION
### [Remove pinned click version bound](https://github.com/appsignal/appsignal-python/commit/904153dfaac06ab569e8ccf3fd301772429f445c)

This was a workaround for an issue on an earlier version of `hatch`,
which has now been fixed.

See: https://github.com/appsignal/appsignal-python/pull/245

### [Pin CI tests to virtualenv version 20](https://github.com/appsignal/appsignal-python/commit/6bcb100b56bdb614cb5d64465d7cc4b041b430f0)

An issue with newer versions of `virtualenv` breaks `hatch` runs in
Python 3.8 and 3.9.

See: https://github.com/pypa/hatch/issues/2193