### PR TITLE
Fix collector mode helpers

### DIFF
--- a/.changesets/emit-action-name-in-collector-mode.md
+++ b/.changesets/emit-action-name-in-collector-mode.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+type: fix
+integrations: all
+---
+
+Emit the `appsignal.action_name` attribute instead of `appsignal.root_name`
+when `set_root_name` is used in collector mode. The collector only reads the
+action name from `appsignal.action_name`, so root names set this way were
+previously ignored, falling back to the OpenTelemetry span name.

--- a/.changesets/emit-action-name-in-collector-mode.md
+++ b/.changesets/emit-action-name-in-collector-mode.md
@@ -1,7 +1,6 @@
 ---
 bump: patch
 type: fix
-integrations: all
 ---
 
 Emit the `appsignal.action_name` attribute instead of `appsignal.root_name`

--- a/.changesets/sanitize-sql-body-in-collector-mode.md
+++ b/.changesets/sanitize-sql-body-in-collector-mode.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+type: fix
+---
+
+Emit the `db.system.name` and `db.query.text` semantic-convention attributes
+instead of `appsignal.sql_body` when `set_sql_body` is used in collector
+mode. This fixes SQL query sanitization when using the experimental collector
+mode. 

--- a/.changesets/update-span-name-in-collector-mode.md
+++ b/.changesets/update-span-name-in-collector-mode.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+type: fix
+---
+
+Update the OpenTelemetry span name directly when `set_name` is used in
+collector mode, instead of setting the `appsignal.name` attribute. The
+collector uses the span name as-is, so names set this way were previously
+ignored.

--- a/src/appsignal/tracing.py
+++ b/src/appsignal/tracing.py
@@ -44,6 +44,14 @@ def _set_prefixed_attribute(
         _set_attribute(f"{prefix}.{suffix}", value, span)
 
 
+def _use_collector() -> bool:
+    # Imported here to avoid an import cycle with the client module.
+    from .client import Client
+
+    config = Client.config()
+    return config is not None and config.should_use_collector()
+
+
 def set_params(params: Any, span: Span | None = None) -> None:
     _set_serialised_attribute("appsignal.request.parameters", params, span)
 
@@ -85,7 +93,12 @@ def set_namespace(namespace: str, span: Span | None = None) -> None:
 
 
 def set_root_name(root_name: str, span: Span | None = None) -> None:
-    _set_attribute("appsignal.root_name", root_name, span)
+    # The collector reads the action name from `appsignal.action_name`, while
+    # the agent reads it from `appsignal.root_name`.
+    if _use_collector():
+        _set_attribute("appsignal.action_name", root_name, span)
+    else:
+        _set_attribute("appsignal.root_name", root_name, span)
 
 
 def set_error(error: Exception, span: Span | None = None) -> None:

--- a/src/appsignal/tracing.py
+++ b/src/appsignal/tracing.py
@@ -44,6 +44,16 @@ def _set_prefixed_attribute(
         _set_attribute(f"{prefix}.{suffix}", value, span)
 
 
+def _update_span_name(name: str, span: Span | None = None) -> None:
+    span = span or trace.get_current_span()
+
+    if span is trace.INVALID_SPAN:
+        logger.debug("There is no active span, cannot set `name`")
+        return
+
+    span.update_name(name)
+
+
 def _use_collector() -> bool:
     # Imported here to avoid an import cycle with the client module.
     from .client import Client
@@ -73,7 +83,13 @@ def set_header(header: str, value: Any, span: Span | None = None) -> None:
 
 
 def set_name(name: str, span: Span | None = None) -> None:
-    _set_attribute("appsignal.name", name, span)
+    # The collector uses the span name directly, and its enrichers cannot
+    # override it, so update the span name. The agent derives the name from
+    # semantic conventions, so set an attribute it honors as a hard override.
+    if _use_collector():
+        _update_span_name(name, span)
+    else:
+        _set_attribute("appsignal.name", name, span)
 
 
 def set_category(category: str, span: Span | None = None) -> None:

--- a/src/appsignal/tracing.py
+++ b/src/appsignal/tracing.py
@@ -101,7 +101,14 @@ def set_body(body: str, span: Span | None = None) -> None:
 
 
 def set_sql_body(body: str, span: Span | None = None) -> None:
-    _set_attribute("appsignal.sql_body", body, span)
+    # The collector sanitizes SQL via the `db.query.text` attribute, gated on
+    # `db.system.name` being set to a recognized SQL system. The agent
+    # sanitizes via the `appsignal.sql_body` magic attribute.
+    if _use_collector():
+        _set_attribute("db.system.name", "other_sql", span)
+        _set_attribute("db.query.text", body, span)
+    else:
+        _set_attribute("appsignal.sql_body", body, span)
 
 
 def set_namespace(namespace: str, span: Span | None = None) -> None:

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from opentelemetry import trace
 from opentelemetry.trace import StatusCode
 
-from appsignal.client import Client
-
 from appsignal import (
     send_error,
     send_error_with_context,
@@ -21,6 +19,7 @@ from appsignal import (
     set_sql_body,
     set_tag,
 )
+from appsignal.client import Client
 
 
 tracer = trace.get_tracer("appsignal/tests")
@@ -96,6 +95,23 @@ def test_set_name_collector_mode(spans):
     span = spans()[0]
     assert span.name == "New name"
     assert "appsignal.name" not in dict(span.attributes)
+
+
+def test_set_sql_body_collector_mode(spans):
+    Client(
+        active=True,
+        name="MyApp",
+        push_api_key="0000-0000-0000-0000",
+        collector_endpoint="https://custom-endpoint.appsignal.com",
+    )
+
+    with tracer.start_as_current_span("span"):
+        set_sql_body("SELECT * FROM users")
+
+    attributes = dict(spans()[0].attributes)
+    assert attributes["db.system.name"] == "other_sql"
+    assert attributes["db.query.text"] == "SELECT * FROM users"
+    assert "appsignal.sql_body" not in attributes
 
 
 def test_set_attributes_on_span(spans):

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from opentelemetry import trace
 from opentelemetry.trace import StatusCode
 
+from appsignal.client import Client
+
 from appsignal import (
     send_error,
     send_error_with_context,
@@ -62,6 +64,22 @@ def test_set_attributes(spans):
         "appsignal.namespace": "web",
         "appsignal.root_name": "Root name",
     }
+
+
+def test_set_root_name_collector_mode(spans):
+    Client(
+        active=True,
+        name="MyApp",
+        push_api_key="0000-0000-0000-0000",
+        collector_endpoint="https://custom-endpoint.appsignal.com",
+    )
+
+    with tracer.start_as_current_span("span"):
+        set_root_name("Root name")
+
+    attributes = dict(spans()[0].attributes)
+    assert attributes["appsignal.action_name"] == "Root name"
+    assert "appsignal.root_name" not in attributes
 
 
 def test_set_attributes_on_span(spans):

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -82,6 +82,22 @@ def test_set_root_name_collector_mode(spans):
     assert "appsignal.root_name" not in attributes
 
 
+def test_set_name_collector_mode(spans):
+    Client(
+        active=True,
+        name="MyApp",
+        push_api_key="0000-0000-0000-0000",
+        collector_endpoint="https://custom-endpoint.appsignal.com",
+    )
+
+    with tracer.start_as_current_span("span"):
+        set_name("New name")
+
+    span = spans()[0]
+    assert span.name == "New name"
+    assert "appsignal.name" not in dict(span.attributes)
+
+
 def test_set_attributes_on_span(spans):
     with tracer.start_as_current_span("parent span") as span:
         with tracer.start_as_current_span("child span"):


### PR DESCRIPTION
### [Emit action_name attribute in collector mode](https://github.com/appsignal/appsignal-python/commit/8ef25799e905e958bfdd82bbba000c3b1213b7b5)

The collector reads the action name from `appsignal.action_name`,
but `set_root_name` only emitted `appsignal.root_name`, which the
collector ignores. In collector mode, emit `appsignal.action_name`
so root names set this way are honored instead of falling back to
the OpenTelemetry span name.

### [Update span name directly in collector mode](https://github.com/appsignal/appsignal-python/commit/c4e330cffe007ad8120355fcf363cc4bde427246)

In collector mode, `set_name` now updates the OpenTelemetry span
name instead of setting the `appsignal.name` attribute. The
collector uses the span name as-is and its enrichers can't override
it, so the attribute is unnecessary there. The agent still gets the
attribute, which it honors as a hard override over its semantic
convention name extraction.

### [Sanitise SQL queries in collector mode](https://github.com/appsignal/appsignal-python/commit/9e39953be751618d3e463b50761dfef186867f9a)

When `set_sql_body` is used in collector mode, emit attributes
following the OpenTelemetry Semantic Conventions for Database Spans,
as the collector expects, rather than the `appsignal.sql_body`
attribute that the agent expects.