### PR TITLE
Send request sample data in collector mode

### DIFF
--- a/.changesets/send-request-sample-data-in-collector-mode.md
+++ b/.changesets/send-request-sample-data-in-collector-mode.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+type: fix
+---
+
+Emit request parameters and headers using the attribute names the collector
+recognizes when in collector mode. `set_params` now emits
+`appsignal.request.payload` instead of `appsignal.request.parameters`, and
+`set_header` uses the `http.request.header` prefix instead of
+`appsignal.request.headers`. The collector and server do not recognize the
+previous names, so this sample data was previously dropped in collector mode.

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -58,33 +58,29 @@ def add_celery_instrumentation(_config: Config) -> None:
 
 
 def add_django_instrumentation(_config: Config) -> None:
-    import json
-
     from django.http.request import HttpRequest
     from django.http.response import HttpResponse
     from opentelemetry.instrumentation.django import DjangoInstrumentor
 
+    from .tracing import set_params
+
     def response_hook(span: Span, request: HttpRequest, response: HttpResponse) -> None:
-        span.set_attribute(
-            "appsignal.request.parameters",
-            json.dumps({"GET": request.GET, "POST": request.POST}),
-        )
+        set_params({"GET": request.GET, "POST": request.POST}, span)
 
     DjangoInstrumentor().instrument(response_hook=response_hook)
 
 
 def add_flask_instrumentation(_config: Config) -> None:
-    import json
     from urllib.parse import parse_qs
 
     from opentelemetry.instrumentation.flask import FlaskInstrumentor
 
+    from .tracing import set_params
+
     def request_hook(span: Span, environ: dict[str, str]) -> None:
         if span and span.is_recording():
             query_params = parse_qs(environ.get("QUERY_STRING", ""))
-            span.set_attribute(
-                "appsignal.request.parameters", json.dumps({"args": query_params})
-            )
+            set_params({"args": query_params}, span)
 
     FlaskInstrumentor().instrument(request_hook=request_hook)
 

--- a/src/appsignal/tracing.py
+++ b/src/appsignal/tracing.py
@@ -63,7 +63,14 @@ def _use_collector() -> bool:
 
 
 def set_params(params: Any, span: Span | None = None) -> None:
-    _set_serialised_attribute("appsignal.request.parameters", params, span)
+    # The collector and server recognize `appsignal.request.payload` for request
+    # body / merged parameters; the agent recognizes `appsignal.request.parameters`.
+    attribute = (
+        "appsignal.request.payload"
+        if _use_collector()
+        else "appsignal.request.parameters"
+    )
+    _set_serialised_attribute(attribute, params, span)
 
 
 def set_session_data(session_data: Any, span: Span | None = None) -> None:
@@ -79,7 +86,11 @@ def set_tag(tag: str, value: Any, span: Span | None = None) -> None:
 
 
 def set_header(header: str, value: Any, span: Span | None = None) -> None:
-    _set_prefixed_attribute("appsignal.request.headers", header, value, span)
+    # The collector and server read request headers from the OpenTelemetry
+    # semantic-convention prefix `http.request.header`; the agent reads them
+    # from `appsignal.request.headers`.
+    prefix = "http.request.header" if _use_collector() else "appsignal.request.headers"
+    _set_prefixed_attribute(prefix, header, value, span)
 
 
 def set_name(name: str, span: Span | None = None) -> None:

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -97,6 +97,38 @@ def test_set_name_collector_mode(spans):
     assert "appsignal.name" not in dict(span.attributes)
 
 
+def test_set_params_collector_mode(spans):
+    Client(
+        active=True,
+        name="MyApp",
+        push_api_key="0000-0000-0000-0000",
+        collector_endpoint="https://custom-endpoint.appsignal.com",
+    )
+
+    with tracer.start_as_current_span("span"):
+        set_params({"id": 123})
+
+    attributes = dict(spans()[0].attributes)
+    assert attributes["appsignal.request.payload"] == '{"id": 123}'
+    assert "appsignal.request.parameters" not in attributes
+
+
+def test_set_header_collector_mode(spans):
+    Client(
+        active=True,
+        name="MyApp",
+        push_api_key="0000-0000-0000-0000",
+        collector_endpoint="https://custom-endpoint.appsignal.com",
+    )
+
+    with tracer.start_as_current_span("span"):
+        set_header("content-type", "application/json")
+
+    attributes = dict(spans()[0].attributes)
+    assert attributes["http.request.header.content-type"] == "application/json"
+    assert "appsignal.request.headers.content-type" not in attributes
+
+
 def test_set_sql_body_collector_mode(spans):
     Client(
         active=True,


### PR DESCRIPTION
Emit request parameters and headers under the attribute names the
collector and server recognize when running in collector mode. Parameters
move from `appsignal.request.parameters` to `appsignal.request.payload`,
and headers from the `appsignal.request.headers` prefix to the
`http.request.header` semantic-convention prefix.

Neither the collector nor the server recognized the previous names, so
this sample data was silently dropped from the trace UI in collector
mode. Agent mode keeps the existing names. The Django and Flask hooks now
route through `set_params` so they pick up the branch too.