### PR TITLE
Test send_error_with_context closes span on raise

### DIFF
--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from opentelemetry import trace
 from opentelemetry.trace import StatusCode
 
@@ -245,3 +246,20 @@ def test_send_error_with_context(spans):
         assert event.name == "exception"
         assert event.attributes["exception.type"] == "tests.test_tracing.FooError"
         assert event.attributes["exception.message"] == "Whoops!"
+
+
+def test_send_error_with_context_closes_span_when_block_raises(spans):
+    # An error raised inside the `with` block bubbles out to the caller, but the
+    # error span is still ended and exported.
+    with pytest.raises(RuntimeError, match="Kaboom!"):
+        with send_error_with_context(raised_error()):
+            raise RuntimeError("Kaboom!")
+
+    span = spans()[0]
+    assert span.name == "FooError"
+    assert span.status.status_code == StatusCode.ERROR
+
+    event = span.events[0]
+    assert event.name == "exception"
+    assert event.attributes["exception.type"] == "tests.test_tracing.FooError"
+    assert event.attributes["exception.message"] == "Whoops!"


### PR DESCRIPTION
Port the regression test from appsignal/appsignal-nodejs#1449. Unlike the
Node.js helper, which had to be fixed to end the span in a finally
block, the Python helper already closes the error span when the
`with` block raises, since it builds on OpenTelemetry's
start_as_current_span context manager. This locks in that behaviour.