### PR TITLE
Use `app` as the default service name

### DIFF
--- a/.changesets/default-service-name-to-app.md
+++ b/.changesets/default-service-name-to-app.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+type: change
+---
+
+Report `app` instead of `unknown` as the OpenTelemetry service name when the
+`service_name` configuration option is not set and collector mode is in use.

--- a/.changesets/report-host-name-when-set-to-none.md
+++ b/.changesets/report-host-name-when-set-to-none.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: fix
+---
+
+Report `unknown` as the host name in collector mode when the `hostname`
+configuration option is set to `None`. Apps that set it that way reported no
+host name at all.

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -288,10 +288,10 @@ def _resource(config: Config) -> Resource:
             "appsignal.config.name": config.options.get("name"),
             "appsignal.config.environment": config.options.get("environment"),
             "appsignal.config.push_api_key": config.options.get("push_api_key"),
-            "appsignal.config.revision": config.options.get("revision", "unknown"),
+            "appsignal.config.revision": config.options.get("revision") or "unknown",
             "appsignal.config.language_integration": "python",
             "service.name": config.options.get("service_name") or "app",
-            "host.name": config.options.get("hostname", "unknown"),
+            "host.name": config.options.get("hostname") or "unknown",
             "appsignal.service.process_id": os.getpid(),
             "appsignal.config.filter_attributes": config.options.get(
                 "filter_attributes"

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -290,7 +290,7 @@ def _resource(config: Config) -> Resource:
             "appsignal.config.push_api_key": config.options.get("push_api_key"),
             "appsignal.config.revision": config.options.get("revision", "unknown"),
             "appsignal.config.language_integration": "python",
-            "service.name": config.options.get("service_name", "unknown"),
+            "service.name": config.options.get("service_name") or "app",
             "host.name": config.options.get("hostname", "unknown"),
             "appsignal.service.process_id": os.getpid(),
             "appsignal.config.filter_attributes": config.options.get(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -349,13 +349,15 @@ def test_opentelemetry_resource_with_defaults():
     assert "appsignal.config.push_api_key" not in resource.attributes
 
 
-def test_opentelemetry_resource_with_none_service_name():
+def test_opentelemetry_resource_with_none_values():
     from appsignal.opentelemetry import _resource
 
-    config = Config(Options(service_name=None))
+    config = Config(Options(revision=None, service_name=None, hostname=None))
     resource = _resource(config)
 
+    assert resource.attributes["appsignal.config.revision"] == "unknown"
     assert resource.attributes["service.name"] == "app"
+    assert resource.attributes["host.name"] == "unknown"
 
 
 def test_set_private_environ_valid_log_path():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -341,12 +341,21 @@ def test_opentelemetry_resource_with_defaults():
 
     # Test default values
     assert resource.attributes["appsignal.config.revision"] == "unknown"
-    assert resource.attributes["service.name"] == "unknown"
+    assert resource.attributes["service.name"] == "app"
     assert resource.attributes["appsignal.config.language_integration"] == "python"
 
     # Test that None values are excluded
     assert "appsignal.config.name" not in resource.attributes
     assert "appsignal.config.push_api_key" not in resource.attributes
+
+
+def test_opentelemetry_resource_with_none_service_name():
+    from appsignal.opentelemetry import _resource
+
+    config = Config(Options(service_name=None))
+    resource = _resource(config)
+
+    assert resource.attributes["service.name"] == "app"
 
 
 def test_set_private_environ_valid_log_path():


### PR DESCRIPTION
### [Use `app` as the default service name](https://github.com/appsignal/appsignal-python/commit/fcf33d89d916aedd1fcf8488599f13df2e8df2f8)

The collector turns the service name into names that customers see. A
trace's namespace becomes `{service name}/{namespace}`, so a web
request from an app that does not set `service_name` was filed under
`unknown/web`. A log line's group falls back to the service name on
its own, so those lines were grouped under `unknown`.

Leaving `service_name` unset is the normal case for an app that is a
single service. Nothing about it is actually unknown, so the fallback
now describes what it is. The `revision` and `hostname` fallbacks
still report `unknown`, because those are facts about the running
process that AppSignal really does not have.

### [Apply revision and host name fallbacks to None](https://github.com/appsignal/appsignal-python/commit/3e289ce679a7844a5b3b0dda0abd14bddbb05a9f)

The OpenTelemetry resource looks up `revision` and `hostname` with a
dictionary default, which only applies when the key is missing. Passing
either option as `None` puts the key in the config with a `None` value,
so the lookup returns that `None` and the resource builder drops the
attribute. The collector supplies its own revision when the attribute is
absent, but not its own host name, so an app configured with
`hostname=None` reported no host name at all.

