### PR TITLE
Send app_path and ignore_logs to the collector

### DIFF
--- a/.changesets/add-the-ignore-logs-option.md
+++ b/.changesets/add-the-ignore-logs-option.md
@@ -1,0 +1,8 @@
+---
+bump: minor
+type: add
+---
+
+Add an `ignore_logs` option, which takes a list of patterns. Log lines that match any of the patterns are not sent to AppSignal. Set it with the `APPSIGNAL_IGNORE_LOGS` environment variable, or as an option on the `Appsignal` client. Read our [ignore logs guide](https://docs.appsignal.com/guides/filter-data/ignore-logs.html) for the patterns that are supported.
+
+This option only has an effect in collector mode, because that is the only mode in which this package sends logs.

--- a/.changesets/send-the-app-path-to-the-collector.md
+++ b/.changesets/send-the-app-path-to-the-collector.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+In collector mode, backtrace lines from your own application are now shown as paths relative to your application's root, and are recognized as your application's code.

--- a/src/appsignal/config.py
+++ b/src/appsignal/config.py
@@ -40,6 +40,7 @@ class Options(TypedDict, total=False):
     http_proxy: str | None
     ignore_actions: list[str] | None
     ignore_errors: list[str] | None
+    ignore_logs: list[str] | None
     ignore_namespaces: list[str] | None
     log: str | None
     log_level: str | None
@@ -224,6 +225,7 @@ class Config:
             http_proxy=os.environ.get("APPSIGNAL_HTTP_PROXY"),
             ignore_actions=parse_list(os.environ.get("APPSIGNAL_IGNORE_ACTIONS")),
             ignore_errors=parse_list(os.environ.get("APPSIGNAL_IGNORE_ERRORS")),
+            ignore_logs=parse_list(os.environ.get("APPSIGNAL_IGNORE_LOGS")),
             ignore_namespaces=parse_list(os.environ.get("APPSIGNAL_IGNORE_NAMESPACES")),
             log=os.environ.get("APPSIGNAL_LOG"),
             log_level=os.environ.get("APPSIGNAL_LOG_LEVEL"),
@@ -433,6 +435,7 @@ class Config:
             "filter_function_parameters",
             "filter_request_payload",
             "filter_request_query_parameters",
+            "ignore_logs",
             "response_headers",
             "send_function_parameters",
             "send_request_payload",

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -311,6 +311,7 @@ def _resource(config: Config) -> Resource:
             ),
             "appsignal.config.ignore_actions": config.options.get("ignore_actions"),
             "appsignal.config.ignore_errors": config.options.get("ignore_errors"),
+            "appsignal.config.ignore_logs": config.options.get("ignore_logs"),
             "appsignal.config.ignore_namespaces": config.options.get(
                 "ignore_namespaces"
             ),

--- a/src/appsignal/opentelemetry.py
+++ b/src/appsignal/opentelemetry.py
@@ -289,6 +289,7 @@ def _resource(config: Config) -> Resource:
             "appsignal.config.environment": config.options.get("environment"),
             "appsignal.config.push_api_key": config.options.get("push_api_key"),
             "appsignal.config.revision": config.options.get("revision") or "unknown",
+            "appsignal.config.app_path": config.options.get("app_path"),
             "appsignal.config.language_integration": "python",
             "service.name": config.options.get("service_name") or "app",
             "host.name": config.options.get("hostname") or "unknown",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -62,6 +62,7 @@ def test_environ_source():
     os.environ["APPSIGNAL_HTTP_PROXY"] = "http://proxy.local:9999"
     os.environ["APPSIGNAL_IGNORE_ACTIONS"] = "action1,action2"
     os.environ["APPSIGNAL_IGNORE_ERRORS"] = "error1,error2"
+    os.environ["APPSIGNAL_IGNORE_LOGS"] = "^log1,^log2"
     os.environ["APPSIGNAL_IGNORE_NAMESPACES"] = "namespace1,namespace2"
     os.environ["APPSIGNAL_LOG_LEVEL"] = "trace"
     os.environ["APPSIGNAL_LOG_PATH"] = "/path/to/log_dir"
@@ -99,6 +100,7 @@ def test_environ_source():
         http_proxy="http://proxy.local:9999",
         ignore_actions=["action1", "action2"],
         ignore_errors=["error1", "error2"],
+        ignore_logs=["^log1", "^log2"],
         ignore_namespaces=["namespace1", "namespace2"],
         log_level="trace",
         log_path="/path/to/log_dir",
@@ -274,6 +276,7 @@ def test_opentelemetry_resource():
             filter_session_data=["session1"],
             ignore_actions=["action1", "action2"],
             ignore_errors=["error1"],
+            ignore_logs=["^log1"],
             ignore_namespaces=["namespace1"],
             response_headers=["x-response"],
             request_headers=["x-request"],
@@ -321,6 +324,7 @@ def test_opentelemetry_resource():
         "action2",
     )
     assert resource.attributes["appsignal.config.ignore_errors"] == ("error1",)
+    assert resource.attributes["appsignal.config.ignore_logs"] == ("^log1",)
     assert resource.attributes["appsignal.config.ignore_namespaces"] == ("namespace1",)
 
     # Test header attributes
@@ -530,6 +534,7 @@ def test_warn_all_collector_exclusive_options(mocker):
                 filter_function_parameters=["param1"],
                 filter_request_payload=["payload1"],
                 filter_request_query_parameters=["query1"],
+                ignore_logs=["^log1"],
                 response_headers=["x-response"],
                 send_function_parameters=True,
                 send_request_payload=True,
@@ -558,6 +563,7 @@ def test_warn_all_collector_exclusive_options(mocker):
             "filter_function_parameters",
             "filter_request_payload",
             "filter_request_query_parameters",
+            "ignore_logs",
             "response_headers",
             "send_function_parameters",
             "send_request_payload",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -264,6 +264,7 @@ def test_opentelemetry_resource():
             environment="test",
             push_api_key="test-key",
             revision="abc123",
+            app_path="/path/to/app",
             service_name="test-service",
             hostname="test-host",
             filter_attributes=["password", "secret"],
@@ -290,6 +291,7 @@ def test_opentelemetry_resource():
     assert resource.attributes["appsignal.config.environment"] == "test"
     assert resource.attributes["appsignal.config.push_api_key"] == "test-key"
     assert resource.attributes["appsignal.config.revision"] == "abc123"
+    assert resource.attributes["appsignal.config.app_path"] == "/path/to/app"
     assert resource.attributes["appsignal.config.language_integration"] == "python"
     assert resource.attributes["service.name"] == "test-service"
     assert resource.attributes["host.name"] == "test-host"


### PR DESCRIPTION
Fixes https://github.com/appsignal/appsignal-python/issues/273.
Fixes https://github.com/appsignal/appsignal-python/issues/275.

### [Send the app path to the collector](https://github.com/appsignal/appsignal-python/commit/bb3759a2a0a015c44a31b37718d33396d948367e)

The processor strips the app path from each backtrace line, and decides
whether a frame belongs to the application by checking that its path is
relative. Without the app path, every frame keeps its absolute path, so
no line is recognized as the application's own.

### [Add the ignore_logs option](https://github.com/appsignal/appsignal-python/commit/723fc30bb5fde2899562028c20c937b6bce791b2)

Collector mode sends log records, and the collector filters out the ones
matching this option when the resource carries it. The package had no
option for it because agent mode sends no logs at all, which is also why
it is not passed on to the agent.

The option is documented in https://github.com/appsignal/appsignal-docs/pull/192,
including that it only has an effect in collector mode.
